### PR TITLE
Charge-density based interstitial finder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     entry: codespell
     language: python
     types: [text]
-    args: [--ignore-words-list, 'titel,statics,ba,nd,te']
+    args: [--ignore-words-list, 'titel,statics,ba,nd,te,mater']
 - repo: https://github.com/kynan/nbstripout
   rev: 0.3.9
   hooks:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
     "restructuredtext.confPath": "",
-    "esbonio.sphinx.confDir": ""
+    "esbonio.sphinx.confDir": "",
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.formatting.provider": "black"
 }

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -511,12 +511,12 @@ class ChargeInsertionAnalyzer(MSONable):
         avg_chg_first_member = {}
         for lab, g in lab_groups.items():
             avg_chg_first_member[lab] = get_avg_chg(
-                self.chgcar, fcoord=fcoords[g[0]], radius=self.avg_radius
+                self.chgcar, fcoord=fcoords[g[0]], radius=avg_radius
             )
 
         res = []
         for lab, avg_chg in sorted(avg_chg_first_member.items(), key=lambda x: x[1]):
-            if avg_chg > self.max_avg_charge:
+            if avg_chg > max_avg_charge:
                 break
             res.append((avg_chg, lab_groups[lab]))
 

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -3,31 +3,37 @@ from __future__ import annotations
 
 import logging
 import math
+import operator
 from copy import deepcopy
 from pathlib import Path
+from typing import Generator
 
 import numpy as np
+from monty.dev import requires
 from monty.json import MSONable
+from numpy import typing as npt
 from numpy.linalg import norm
 from pymatgen.analysis.local_env import cn_opt_params
+from pymatgen.core import Lattice
+from pymatgen.io.vasp import VolumetricData
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import squareform
 
 try:
-    pass
+    from skimage.feature import peak_local_max
 
     peak_local_max_found = True
 except ImportError:
     peak_local_max_found = False
 
 __author__ = (
-    "Danny Broberg, Shyam Dwaraknath, Bharat Medasani, Nils Zimmermann, "
+    "Jimmy-Xuan Shen, Danny Broberg, Shyam Dwaraknath, Bharat Medasani, Nils Zimmermann, "
     "Geoffroy Hautier"
 )
-__copyright__ = "Copyright 2014, The Materials Project"
-__version__ = "1.0"
-__maintainer__ = "Danny Broberg, Shyam Dwaraknath"
-__email__ = "dbroberg@berkeley.edu, shyamd@lbl.gov"
+__maintainer__ = "Jimmy-Xuan Shen"
+__email__ = "jmmshn@gmail.com"
 __status__ = "Development"
-__date__ = "January 11, 2018"
+__date__ = "Aug 15, 2022"
 
 logger = logging.getLogger(__name__)
 hart_to_ev = 27.2114
@@ -112,7 +118,7 @@ def eV_to_k(energy):
     return math.sqrt(energy / invang_to_ev) * ang_to_bohr
 
 
-def genrecip(a1, a2, a3, encut):
+def genrecip(a1, a2, a3, encut) -> Generator[npt.ArrayLike, None, None]:
     """Generate reciprocal lattice vectors within the energy cutoff.
 
     Args:
@@ -120,6 +126,7 @@ def genrecip(a1, a2, a3, encut):
         a2: Lattice vector b (in Bohrs)
         a3: Lattice vector c (in Bohrs)
         encut: energy cut off in eV
+
     Returns:
         reciprocal lattice vectors with energy less than encut
     """
@@ -221,3 +228,148 @@ def get_zfile(
         return None
 
     raise FileNotFoundError(f"Could not find {base_name} or {base_name}.gz file.")
+
+
+def generic_groupby(list_in, comp=operator.eq):
+    """
+    Group a list of unsortable objects
+    Args:
+        list_in: A list of generic objects
+        comp: (Default value = operator.eq) The comparator
+    Returns:
+        [int] list of labels for the input list
+    """
+    list_out = [None] * len(list_in)
+    label_num = 0
+    for i1, ls1 in enumerate(list_out):
+        if ls1 is not None:
+            continue
+        list_out[i1] = label_num
+        for i2, ls2 in list(enumerate(list_out))[(i1 + 1) :]:
+            if comp(list_in[i1], list_in[i2]):
+                if ls2 is None:
+                    list_out[i2] = list_out[i1]
+                else:
+                    list_out[i1] = ls2
+                    label_num -= 1
+        label_num += 1
+    return list_out
+
+
+@requires(
+    peak_local_max_found,
+    "get_local_extrema requires skimage.feature.peak_local_max module"
+    " to be installed. Please confirm your skimage installation.",
+)
+def get_local_extrema(chgcar: VolumetricData, find_min: bool = True) -> npt.NDArray:
+    """
+    Get all local extrema fractional coordinates in charge density,
+    searching for local minimum by default. Note that sites are NOT grouped
+    symmetrically.
+
+    Args:
+        find_min (bool): True to find local minimum else maximum, otherwise
+            find local maximum.
+
+    Returns:
+        extrema_coords (list): list of fractional coordinates corresponding
+            to local extrema.
+    """
+
+    if find_min:
+        sign = -1
+    else:
+        sign = 1
+
+    # Make 3x3x3 supercell
+    # This is a trick to resolve the periodical boundary issue.
+    # TODO: Add code to pyrho for max and min filtering.
+    total_chg = sign * chgcar.data["total"]
+    total_chg = np.tile(total_chg, reps=(3, 3, 3))
+    coordinates = peak_local_max(total_chg, min_distance=1)
+
+    # Remove duplicated sites introduced by supercell.
+    f_coords = [coord / total_chg.shape * 3 for coord in coordinates]
+    f_coords = [
+        f - 1 for f in f_coords if all(np.array(f) < 2) and all(np.array(f) >= 1)
+    ]
+
+    return np.array(f_coords)
+
+
+def cluster_nodes(
+    vf_coords: npt.ArrayLike, lattice: Lattice, tol: float = 0.2
+) -> npt.NDArray:
+    """
+    Cluster nodes that are too close together using a tol.
+
+    Args:
+        tol (float): A distance tolerance. PBC is taken into account.
+    """
+    # Manually generate the distance matrix (which needs to take into
+    # account PBC.
+    dist_matrix = np.array(lattice.get_all_distances(vf_coords, vf_coords))
+    dist_matrix = (dist_matrix + dist_matrix.T) / 2
+
+    for i in range(len(dist_matrix)):
+        dist_matrix[i, i] = 0
+    condensed_m = squareform(dist_matrix)
+    z = linkage(condensed_m)
+    cn = fcluster(z, tol, criterion="distance")
+    merged_fcoords = []
+
+    for n in set(cn):
+        frac_coords = []
+        for i, j in enumerate(np.where(cn == n)[0]):
+            if i == 0:
+                frac_coords.append(vf_coords[j])
+            else:
+                f_coords = vf_coords[j]
+                # We need the image to combine the frac_coords properly.
+                d, image = lattice.get_distance_and_image(frac_coords[0], f_coords)
+                frac_coords.append(f_coords + image)
+        merged_fcoords.append(np.average(frac_coords, axis=0))
+
+    merged_fcoords = [f - np.floor(f) for f in merged_fcoords]
+    merged_fcoords = [f * (np.abs(f - 1) > 1e-15) for f in merged_fcoords]
+    # the second line for fringe cases like
+    # np.array([ 5.0000000e-01 -4.4408921e-17  5.0000000e-01])
+    # where the shift to [0,1) does not work due to float precision
+
+    return np.array(merged_fcoords)
+
+
+def get_avg_chg(
+    chgcar: VolumetricData, fcoord: npt.NDArray, radius: float = 0.4
+) -> float:
+    """Get the average charge in a sphere.
+
+    Args:
+        chgcar: The charge density.
+        fcoord: The fractional coordinates of the center of the sphere.
+        radius: The radius of the sphere in Angstroms.
+
+    Returns:
+        The average charge in the sphere.
+
+
+    """
+
+    def _dist_mat(pos_frac):
+        # return a matrix that contains the distances
+        aa = np.linspace(0, 1, len(chgcar.get_axis_grid(0)), endpoint=False)
+        bb = np.linspace(0, 1, len(chgcar.get_axis_grid(1)), endpoint=False)
+        cc = np.linspace(0, 1, len(chgcar.get_axis_grid(2)), endpoint=False)
+        AA, BB, CC = np.meshgrid(aa, bb, cc, indexing="ij")
+        dist_from_pos = chgcar.structure.lattice.get_all_distances(
+            fcoords1=np.vstack([AA.flatten(), BB.flatten(), CC.flatten()]).T,
+            fcoords2=pos_frac,
+        )
+        return dist_from_pos.reshape(AA.shape)
+
+    if np.any(fcoord < 0) or np.any(fcoord > 1):
+        raise ValueError("f_coords must be in [0,1)")
+    mask = _dist_mat(fcoord) < radius
+    vol_sphere = chgcar.structure.volume * (mask.sum() / chgcar.ngridpts)
+    chg_in_sphere = np.sum(chgcar.data["total"] * mask) / mask.size / vol_sphere
+    return chg_in_sphere

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -340,7 +340,7 @@ def cluster_nodes(
 
 
 def get_avg_chg(
-    chgcar: VolumetricData, fcoord: npt.NDArray, radius: float = 0.4
+    chgcar: VolumetricData, fcoord: npt.ArrayLike, radius: float = 0.4
 ) -> float:
     """Get the average charge in a sphere.
 
@@ -354,6 +354,8 @@ def get_avg_chg(
 
 
     """
+    # makesure fcoord is an array
+    fcoord = np.array(fcoord)
 
     def _dist_mat(pos_frac):
         # return a matrix that contains the distances
@@ -371,5 +373,5 @@ def get_avg_chg(
         raise ValueError("f_coords must be in [0,1)")
     mask = _dist_mat(fcoord) < radius
     vol_sphere = chgcar.structure.volume * (mask.sum() / chgcar.ngridpts)
-    chg_in_sphere = np.sum(chgcar.data["total"] * mask) / mask.size / vol_sphere
-    return chg_in_sphere
+    avg_chg = np.sum(chgcar.data["total"] * mask) / mask.size / vol_sphere
+    return avg_chg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,9 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "pymatgen==2022.7.19",
+  "pymatgen>=2022.7.19",
   "dscribe>=1.2.1",
+  "scikit-image>=0.19.3",
 ]
 description = "Pymatgen extension for defects analysis"
 dynamic = ["version"]
@@ -43,6 +44,7 @@ docs = [
 strict = [
   "pymatgen==2022.7.19",
   "dscribe==1.2.1",
+  "scikit-image==0.19.3",
 ]
 
 tests = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from monty.serialization import loadfn
 from pymatgen.core import Structure
 from pymatgen.core.periodic_table import Specie
-from pymatgen.io.vasp import Locpot, Vasprun
+from pymatgen.io.vasp import Chgcar, Locpot, Vasprun
 
 from pymatgen.analysis.defects.core import PeriodicSite, Substitution
 from pymatgen.analysis.defects.thermo import DefectEntry
@@ -88,3 +88,8 @@ def defect_entries_Mg_Ga(data_Mg_Ga, defect_Mg_Ga):
         defect_entries[qq] = defect_entry
         plot_data[qq] = p_data
     return defect_entries, plot_data
+
+
+@pytest.fixture(scope="session")
+def chgcar_fe3o4(test_dir):
+    return Chgcar.from_file(test_dir / "CHGCAR.Fe3O4.vasp")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,12 @@
+import numpy as np
 from pymatgen.core.periodic_table import Specie
 
-from pymatgen.analysis.defects.core import PeriodicSite, Substitution, Vacancy
+from pymatgen.analysis.defects.core import (
+    Interstitial,
+    PeriodicSite,
+    Substitution,
+    Vacancy,
+)
 
 
 def test_vacancy(gan_struct):
@@ -34,3 +40,16 @@ def test_substitution(gan_struct):
     assert sc.formula == "Ga64 N63 O1"
     assert sub.name == "O_N"
     assert sub == sub
+
+
+def test_interstitial(gan_struct):
+    s = gan_struct.copy()
+    inter_fpos = [0, 0, 0.75]
+    n_site = PeriodicSite(Specie("N"), inter_fpos, s.lattice)
+    inter = Interstitial(s, n_site)
+    assert inter.oxi_state == 3
+    assert inter.get_charge_states() == [-1, 0, 1, 2, 3, 4]
+    assert np.allclose(inter.defect_structure[0].frac_coords, inter_fpos)
+    sc = inter.get_supercell_structure()
+    assert sc.formula == "Ga64 N65"
+    assert inter.name == "N_i"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pymatgen.core.periodic_table import Specie
+from pymatgen.core.periodic_table import Element, Specie
 
 from pymatgen.analysis.defects.core import (
     Interstitial,
@@ -21,6 +21,7 @@ def test_vacancy(gan_struct):
     assert vac.get_supercell_structure().formula == "Ga63 N64"
     assert vac.name == "Va_Ga"
     assert vac == vac
+    assert vac.element_changes == {Element("Ga"): -1}
 
 
 def test_substitution(gan_struct):
@@ -40,6 +41,7 @@ def test_substitution(gan_struct):
     assert sc.formula == "Ga64 N63 O1"
     assert sub.name == "O_N"
     assert sub == sub
+    assert sub.element_changes == {Element("N"): -1, Element("O"): 1}
 
 
 def test_interstitial(gan_struct):
@@ -53,3 +55,5 @@ def test_interstitial(gan_struct):
     sc = inter.get_supercell_structure()
     assert sc.formula == "Ga64 N65"
     assert inter.name == "N_i"
+    assert str(inter) == "N intersitial site at at site [0.00,0.00,0.75]"
+    assert inter.element_changes == {Element("N"): 1}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -65,7 +65,6 @@ def test_chgcar_insertion(chgcar_fe3o4):
     cia = ChargeInsertionAnalyzer(chgcar)
     insert_groups = cia.filter_and_group(max_avg_charge=0.5)
     for (avg_chg, group), (ref_chg, ref_fpos) in zip(insert_groups, insert_ref):
-        print([cia.local_minima[i] for i in group])
         fpos = sorted([cia.local_minima[i] for i in group])
         pytest.approx(avg_chg, ref_chg)
         assert np.allclose(fpos, ref_fpos)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,4 +68,4 @@ def test_chgcar_insertion(chgcar_fe3o4):
         print([cia.local_minima[i] for i in group])
         fpos = sorted([cia.local_minima[i] for i in group])
         pytest.approx(avg_chg, ref_chg)
-        np.allclose(fpos, ref_fpos)
+        assert np.allclose(fpos, ref_fpos)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+from pymatgen.io.vasp.outputs import Chgcar
+
+from pymatgen.analysis.defects.utils import (
+    cluster_nodes,
+    get_avg_chg,
+    get_local_extrema,
+)
+
+
+def test_get_local_extrema(gan_struct):
+    data = np.ones((48, 48, 48))
+    chgcar = Chgcar(poscar=gan_struct, data={"total": data})
+    frac_pos = [[0, 0, 0], [0.25, 0.25, 0.25], [0.5, 0.5, 0.5], [0.75, 0.75, 0.75]]
+    for fpos in frac_pos:
+        idx = np.multiply(fpos, chgcar.data["total"].shape).astype(int)
+        chgcar.data["total"][idx[0], idx[1], idx[2]] = 0
+    loc_min = get_local_extrema(chgcar, frac_pos)
+    for a, b in zip(sorted(loc_min.tolist()), sorted(frac_pos)):
+        assert np.allclose(a, b)
+
+
+def test_cluster_nodes(gan_struct):
+    frac_pos = [
+        [0, 0, 0],
+        [0.25, 0.25, 0.25],
+        [0.5, 0.5, 0.5],
+        [0.75, 0.75, 0.75],
+    ]
+    added = [
+        [0.0002, 0.0001, 0.0001],
+        [0.0002, 0.0002, 0.0003],
+        [0.25001, 0.24999, 0.24999],
+        [0.25, 0.249999, 0.250001],
+    ]  # all the displacements are positive so we dont have to worry about periodic boundary conditions
+    clusters = cluster_nodes(frac_pos + added, gan_struct.lattice)
+
+    for a, b in zip(sorted(clusters.tolist()), sorted(frac_pos)):
+        assert np.allclose(a, b, atol=0.001)
+
+
+def test_get_avg_chg(gan_struct):
+    data = np.ones((48, 48, 48))
+    chgcar = Chgcar(poscar=gan_struct, data={"total": data})
+    fpos = [0.1, 0.1, 0.1]
+    avg_chg_sphere = get_avg_chg(chgcar, fpos)
+    avg_chg = np.sum(chgcar.data["total"]) / chgcar.ngridpts / chgcar.structure.volume
+    pytest.approx(avg_chg_sphere, avg_chg)


### PR DESCRIPTION
# Charge-density-based interstitial finder

Use the local minima in the charge density to identify the insertion position for the interstitial.
The original code was added to `pymatgen` as part of this paper:
    J.-X. Shen et al.: npj Comput. Mater. 6, 1 (2020)
    https://www.nature.com/articles/s41524-020-00422-3

The code has been streamlined and improved here:
- The structure matching is only done once and cached for an object.
- All of the individual operations have been placed into pure functions with their own tests and the `ChargeInsertionAnalyzer` is only responsible for orchestrating them.
