### PR TITLE
refactor generators

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9 ]
+        python-version: [ 3.8, 3.9, 3.10 ]
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
@@ -50,13 +50,8 @@ jobs:
     - uses: actions/setup-python@v2.2.2
       with:
         python-version:  ${{ matrix.python-version }}
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-pip-
+        cache: pip
+        cache-dependency-path: pyproject.toml
 
     - name: Install dependencies
       run: |
@@ -88,7 +83,9 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.8
 
@@ -45,9 +45,9 @@ jobs:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
 
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2.2.2
+    - uses: actions/setup-python@v3
       with:
         python-version:  ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, 3.10 ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,9 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -63,7 +65,7 @@ jobs:
       run: pytest --cov=pymatgen --cov-report=xml
 
     - uses: codecov/codecov-action@v1
-      if: matrix.python-version == 3.8
+      if: matrix.python-version == 3.10
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/update-precommit.yml
+++ b/.github/workflows/update-precommit.yml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Set up Python
-        uses: actions/setup-python@v2.2.2
+      - uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version:  ${{ 3.10 }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -259,7 +259,7 @@ class InterstitialGenerator(DefectGenerator):
             yield fc
 
 
-class ChargeInterstitialGenerator(DefectGenerator):
+class ChargeInterstitialGenerator(InterstitialGenerator):
     def __init__(
         self,
         clustering_tol: float = 0.6,
@@ -285,13 +285,11 @@ class ChargeInterstitialGenerator(DefectGenerator):
         self.ltol = ltol
         self.stol = stol
         self.angle_tol = angle_tol
-        self.min_dist = min_dist
         self.avg_radius = avg_radius
         self.max_avg_charge = max_avg_charge
+        super().__init__(min_dist=min_dist)
 
-    def get_defects(
-        self, chgcar: Chgcar, insert_species: set[str], **kwargs
-    ) -> Generator[Interstitial, None, None]:
+    def get_defects(self, chgcar: Chgcar, insert_species: set[str] | list[str], **kwargs) -> Generator[Interstitial, None, None]:  # type: ignore[override]
         """Generate interstitials.
 
         Args:
@@ -299,11 +297,11 @@ class ChargeInterstitialGenerator(DefectGenerator):
             insert_species: The species to be inserted.
             **kwargs: Additional keyword arguments for the ``Interstitial`` constructor.
         """
+        if len(set(insert_species)) != len(insert_species):
+            raise ValueError("Insert species must be unique.")
         cand_sites = self._get_candidate_sites(chgcar)
         for species in insert_species:
-            yield from InterstitialGenerator.get_defects(
-                self, chgcar.structure, {species: cand_sites}
-            )
+            yield from super().get_defects(chgcar.structure, {species: cand_sites})
 
     def _get_candidate_sites(self, chgcar: Chgcar):
         cia = ChargeInsertionAnalyzer(

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -266,9 +266,9 @@ class ChargeInterstitialGenerator(InterstitialGenerator):
         ltol: float = 0.2,
         stol: float = 0.3,
         angle_tol: float = 5,
-        min_dist: float = 0.5,
+        min_dist: float = 1.0,
         avg_radius: float = 0.4,
-        max_avg_charge: float = 1.0,
+        max_avg_charge: float = 0.9,
     ) -> None:
         """Generator of interstitiald defects.
 
@@ -299,7 +299,7 @@ class ChargeInterstitialGenerator(InterstitialGenerator):
         """
         if len(set(insert_species)) != len(insert_species):
             raise ValueError("Insert species must be unique.")
-        cand_sites = self._get_candidate_sites(chgcar)
+        cand_sites = [*self._get_candidate_sites(chgcar)]
         for species in insert_species:
             yield from super().get_defects(chgcar.structure, {species: cand_sites})
 
@@ -316,7 +316,7 @@ class ChargeInterstitialGenerator(InterstitialGenerator):
             avg_radius=self.avg_radius, max_avg_charge=self.max_avg_charge
         )
         for _, g in avg_chg_groups:
-            yield g[0]
+            yield min(g)
 
 
 def _element_str(sp_or_el: Species | Element) -> str:

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -31,17 +31,18 @@ from __future__ import annotations
 
 import collections
 import logging
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 from itertools import combinations
 from typing import Generator
 
 from monty.json import MSONable
+from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Element, PeriodicSite, Species, Structure
-from pymatgen.io.vasp.outputs import Chgcar
+from pymatgen.io.vasp import Chgcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
-from pymatgen.analysis.defects.core import Defect, Interstitial, Substitution, Vacancy
-from pymatgen.analysis.defects.utils import ChargeInsertionAnalyzer
+from pymatgen.analysis.defects.core import Interstitial, Substitution, Vacancy
+from pymatgen.analysis.defects.utils import ChargeInsertionAnalyzer, remove_collisions
 
 __author__ = "Jimmy-Xuan Shen"
 __copyright__ = "Copyright 2022, The Materials Project"
@@ -52,127 +53,149 @@ logger = logging.getLogger(__name__)
 
 
 class DefectGenerator(MSONable, metaclass=ABCMeta):
-    def __init__(self, structure: Structure, **kwargs):
-        """Abstract class for a defect generator.
+    """Abstract class for a defect generator."""
 
-        Args:
-            structure: The bulk structure the defects are generated from.
-        """
-        self.structure = structure
-        # make sure we only look at structure symmetries
-        self.structure.remove_oxidation_states()
+    def _space_group_analyzer(self, structure: Structure) -> SpacegroupAnalyzer:
+        """Get the ``SpaceGroupAnalyzer``."""
+        struct = _remove_oxidation_states(structure)
+        if hasattr(self, "symprec") and hasattr(self, "angle_tolerance"):
+            return SpacegroupAnalyzer(
+                struct,
+                symprec=self.symprec,
+                angle_tolerance=self.angle_tolerance,
+            )
+        else:
+            raise ValueError("This generator does not have symprec and angle_tolerance")
 
-    def __iter__(self):
-        """Iterate over the defect objects."""
-        for defect in self.generate_defects():
-            yield defect
-
-    @abstractmethod
-    def generate_defects(self, **kwargs) -> Generator[Defect, None, None]:
-        """Generate a list of symmetry-distinct site objects,
-
-        Args:
-            **kwargs: Additional keyword arguments for the ``Defect`` constructor.
-
-        Returns:
-            Generator[Defect, None, None]: Generator that yields a list of ``Defect`` objects
-        """
+    def _stucture_matcher(self) -> StructureMatcher:
+        """Get the ``StructureMatcher``."""
+        if (
+            hasattr(self, "ltol")
+            and hasattr(self, "stol")
+            and hasattr(self, "angle_tol")
+        ):
+            return StructureMatcher(
+                ltol=self.ltol, stol=self.stol, angle_tol=self.angle_tol
+            )
+        else:
+            raise ValueError("This generator does not have symprec and angle_tolerance")
 
 
 class VacancyGenerator(DefectGenerator):
-    def __init__(self, structure: Structure, rm_species: list[str | Species] = None):
-        """Generate vacancy for each symmetry distinct site in a structure.
-
-        Args:
-            structure: The bulk structure the vacancies are generated from.
-            rm_species: List of species to be removed. If None considered all species.
-        """
-        super().__init__(structure)
-        all_species = [*map(str, structure.composition.elements)]
-        if rm_species is None:
-            self.rm_species = all_species
-        else:
-            self.rm_species = [*map(str, rm_species)]
-
-        if not set(self.rm_species).issubset(all_species):
-            raise ValueError(
-                f"rm_species({rm_species}) must be a subset of the structure's species ({all_species})."
-            )
-
-    def generate_defects(
-        self, symprec: float = 0.01, angle_tolerance: float = 5, **kwargs
-    ) -> Generator[Vacancy, None, None]:
-        """Generate a vacancy defects.
+    def __init__(
+        self,
+        symprec: float = 0.01,
+        angle_tolerance: float = 5,
+    ):
+        """Generator for vacancy defects.
 
         Args:
             symprec:  Tolerance for symmetry finding.
             (parameter for ``SpacegroupAnalyzer``).
             angle_tolerance: Angle tolerance for symmetry finding.
             (parameter for ``SpacegroupAnalyzer``).
-            **kwargs: Additional keyword arguments for the ``Defect`` constructor.
+        """
+        self.symprec = symprec
+        self.angle_tolerance = angle_tolerance
+
+    def get_defects(
+        self, structure: Structure, rm_species: list[str | Species] = None, **kwargs
+    ) -> Generator[Vacancy, None, None]:
+        """Generate a vacancy defects.
+
+        Args:
+            structure: The bulk structure the vacancies are generated from.
+            rm_species: List of species to be removed. If None considered all species.
+            **kwargs: Additional keyword arguments for the ``Vacancy`` constructor.
 
         Returns:
-            Generator[Vacancy, None, None]: Generator that yields a list of ``Defect`` objects
+            Generator[Vacancy, None, None]: Generator that yields a list of ``Vacancy`` objects.
         """
-        sga = SpacegroupAnalyzer(
-            self.structure, symprec=symprec, angle_tolerance=angle_tolerance
-        )
+        all_species = [*map(str, structure.composition.elements)]
+
+        if rm_species is None:
+            rm_species = all_species
+        else:
+            rm_species = [*map(str, rm_species)]
+
+        if not set(rm_species).issubset(all_species):
+            raise ValueError(
+                f"rm_species({rm_species}) must be a subset of the structure's species ({all_species})."
+            )
+
+        sga = self._space_group_analyzer(structure)
         sym_struct = sga.get_symmetrized_structure()
         for site_group in sym_struct.equivalent_sites:
             site = site_group[0]
-            if _element_str(site.specie) in self.rm_species:
-                yield Vacancy(self.structure, site, **kwargs)
+            if _element_str(site.specie) in rm_species:
+                yield Vacancy(
+                    structure=_remove_oxidation_states(structure), site=site, **kwargs
+                )
 
 
 class SubstitutionGenerator(DefectGenerator):
-    def __init__(self, structure: Structure, substitution: dict[str, list[str]]):
+    def __init__(self, symprec: float = 0.01, angle_tolerance: float = 5):
         """Generator of substitutions for symmetry distinct sites in a structure.
+
+        Args:
+            symprec:  Tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
+            angle_tolerance: Angle tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
+
+        """
+        self.symprec = symprec
+        self.angle_tolerance = angle_tolerance
+
+    def get_defects(
+        self, structure: Structure, substitution: dict[str, list[str]], **kwargs
+    ) -> Generator[Substitution, None, None]:
+        """Generate subsitutional defects.
 
         Args:
             structure: The bulk structure the vacancies are generated from.
             substitution: The substitutions to be made given as a dictionary.
                 e.g. {"Ga": ["Mg", "Ca"]} means that Ga is substituted with Mg or Ca.
-        """
-        super().__init__(structure)
-        self.substitution = substitution
-
-    def generate_defects(
-        self, symprec: float = 0.01, angle_tolerance: float = 5, **kwargs
-    ) -> Generator[Substitution, None, None]:
-        """Generate a subsitutional defects.
-
-        Args:
-            symprec:  Tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
-            angle_tolerance: Angle tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
-            **kwargs: Additional keyword arguments for the ``Defect`` constructor.
+            **kwargs: Additional keyword arguments for the ``Substitution`` constructor.
 
         Returns:
             Generator[Substitution, None, None]: Generator that yields a list of ``Substitution`` objects
         """
-        sga = SpacegroupAnalyzer(
-            self.structure, symprec=symprec, angle_tolerance=angle_tolerance
-        )
+        sga = self._space_group_analyzer(structure)
         sym_struct = sga.get_symmetrized_structure()
         for site_group in sym_struct.equivalent_sites:
             site = site_group[0]
             el_str = _element_str(site.specie)
-            if el_str not in self.substitution.keys():
+            if el_str not in substitution.keys():
                 continue
-            for sub_el in self.substitution[el_str]:
+            for sub_el in substitution[el_str]:
                 sub_site = PeriodicSite(
                     Species(sub_el),
                     site.frac_coords,
-                    self.structure.lattice,
+                    structure.lattice,
                     properties=site.properties,
                 )
-                yield Substitution(self.structure, sub_site, **kwargs)
+                yield Substitution(structure, sub_site, **kwargs)
 
 
-class AntiSiteGenerator(SubstitutionGenerator):
-    """Generate all anti-site defects."""
+class AntiSiteGenerator(DefectGenerator):
+    def __init__(self, symprec: float = 0.01, angle_tolerance: float = 5):
+        """Generator of all anti-site defects.
 
-    def __init__(self, structure: Structure):
-        """Initialize an anti-site generator.
+        Args:
+            symprec:  Tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
+            angle_tolerance: Angle tolerance for symmetry finding (parameter for ``SpacegroupAnalyzer``).
+
+        Returns:
+            Generator[Substitution, None, None]: Generator that yields a list of ``Substitution`` objects
+        """
+        self.symprec = symprec
+        self.angle_tolerance = angle_tolerance
+
+    def get_defects(
+        self,
+        structure: Structure,
+        **kwargs,
+    ) -> Generator[Substitution, None, None]:
+        """Generate anti-site defects.
 
         Args:
             structure: The bulk structure the anti-site defects are generated from.
@@ -183,82 +206,119 @@ class AntiSiteGenerator(SubstitutionGenerator):
             subs[u].append(v)
             subs[v].append(u)
         logger.debug(f"All anti-site pairings: {subs}")
-        super().__init__(structure, subs)
+        return SubstitutionGenerator.get_defects(self, structure, subs)
 
 
 class InterstitialGenerator(DefectGenerator):
-    def __init__(
-        self,
-        structure: Structure,
-        insertions: dict[str | Species | Element, list[list[float]]],
-    ):
-        """Generator for intersitials defects in structure.
+    def __init__(self, min_dist: float = 0.5) -> None:
+        """Generator of interstitiald defects.
 
         Args:
-            structure: The bulk structure the interstitials atoms are placed in.
-            insertions: Insertions in the form of a dictionary.
-                e.g. ``{"Mg": [[0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]}`` means that we want to generate
-                two interstitials at [0.5, 0.5, 0.5] and [0.25, 0.25, 0.25].
-
+            min_dist: Minimum distance between an interstitial and the nearest atom.
         """
-        super().__init__(structure)
-        self.insertions = insertions
+        self.min_dist = min_dist
 
-    @classmethod
-    def from_chgcar(
-        cls,
-        chgcar: Chgcar,
-        i_species: str | Species | Element,
-        avg_radius: float = 0.4,
-        max_avg_charge: float = 1.0,
-        n_groups: int = None,
-        **kwargs,
-    ) -> InterstitialGenerator:
-        """Generate interstitials from a CHGCAR object.
-
-        Identify the interstitial sites from the CHGCAR object using ``ChargeInsertionAnalyzer``.
-        ``ChargeInsertionAnalyzer`` examines the local minmina in the charge density and organizes
-        them into symmetry equivalent groups.
-        The groups are ranked by the average charge density in ``avg_radius`` around each site,
-        we will filter out groups with average charge density higher than ``max_avg_charge``.
-        If ``n_groups`` is specified, we will only select the ``n_groups`` groups with the lowest
-        average charge density.
+    def get_defects(
+        self, structure: Structure, insertions: dict[str, list[list[float]]], **kwargs
+    ) -> Generator[Interstitial, None, None]:
+        """Generate interstitials.
 
         Args:
-            chgcar: The CHGCAR object.
-            insertions: Insertions in the form of a dictionary.
-                e.g. ``{"Mg": [[0.5, 0.5, 0.5], [0.25, 0.25, 0.25]]}`` means that we want to generate
-                two interstitials at [0.5, 0.5, 0.5] and [0.25, 0.25, 0.25].
-            avg_radius: The radius used to calculate average charge density.
-            max_avg_charge: Do no consider local minmas with avg charge above this value.
-            n_groups: Only consider the n_groups with lowest average charge density. If None, all groups are considered.
-            **kwargs: Other keyword arguments passed to ``ChargeInsertionAnalyzer``.
-
-        Returns:
-            An ``InterstitialGenerator`` object.
-        """
-        cia = ChargeInsertionAnalyzer(chgcar, **kwargs)
-        insert_groups = cia.filter_and_group(
-            avg_radius=avg_radius, max_avg_charge=max_avg_charge
-        )
-        i_pos = [group[0] for _, group in insert_groups]
-        if n_groups is not None:
-            i_pos = i_pos[:n_groups]
-        return cls(cia.chgcar.structure.copy(), insertions={i_species: i_pos})
-
-    def generate_defects(self, **kwargs) -> Generator[Interstitial, None, None]:
-        """Generate interstitials defects.
-
-        Args:
+            structure: The bulk structure the interstitials are generated from.
+            insertions: The insertions to be made given as a dictionary {"Mg": [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]]}.
             **kwargs: Additional keyword arguments for the ``Interstitial`` constructor.
 
         Returns:
             Generator[Interstitial, None, None]: Generator that yields a list of ``Interstitial`` objects
         """
-        for el_str, pos_list in self.insertions.items():
-            for pos in pos_list:
-                isite = PeriodicSite(Species(el_str), pos, self.structure.lattice)
-                yield Interstitial(self.structure, isite, **kwargs)
+        for el_str, coords in insertions.items():
+
+            for coord in self._filter_colliding(coords, structure=structure):
+                isite = PeriodicSite(
+                    species=Species(el_str), coords=coord, lattice=structure.lattice
+                )
+                yield Interstitial(structure, isite, **kwargs)
+
+    def _filter_colliding(
+        self, fcoords: list[list[float]], structure: Structure
+    ) -> Generator[list[float], None, None]:
+        """Check the sites for collisions.
+
+        Args:
+            fcoords: List of fractional coordinates of the sites.
+            structure: The bulk structure the interstitials placed in.
+        """
+        unique_fcoords = set(tuple(f) for f in fcoords)
+        cleaned_fcoords = remove_collisions(
+            fcoords=list(unique_fcoords), structure=structure, min_dist=self.min_dist
+        )
+        cleaned_fcoords = set(tuple(f) for f in cleaned_fcoords)
+        for fc in fcoords:
+            if tuple(fc) not in cleaned_fcoords:
+                continue
+            yield fc
+
+
+class ChargeInterstitialGenerator(DefectGenerator):
+    def __init__(
+        self,
+        clustering_tol: float = 0.6,
+        ltol: float = 0.2,
+        stol: float = 0.3,
+        angle_tol: float = 5,
+        min_dist: float = 0.5,
+        avg_radius: float = 0.4,
+        max_avg_charge: float = 1.0,
+    ) -> None:
+        """Generator of interstitiald defects.
+
+        Args:
+            clustering_tol: Tolerance for clustering see :meth:`pymatgen.analysis.defects.utils.cluster_nodes`.
+            ltol: Tolerance for lattice parameter matching
+            stol: Tolerance for site matching
+            angle_tol: Tolerance for angles in degrees
+            min_dist: Minimum to atoms in the host structure
+            avg_radius: The radius around each local minima used to evaluate the average charge.
+            max_avg_charge: The maximum average charge to accept.
+        """
+        self.clustering_tol = clustering_tol
+        self.ltol = ltol
+        self.stol = stol
+        self.angle_tol = angle_tol
+        self.min_dist = min_dist
+        self.avg_radius = avg_radius
+        self.max_avg_charge = max_avg_charge
+
+    def get_defects(
+        self, chgcar: Chgcar, insert_species: set[str], **kwargs
+    ) -> Generator[Interstitial, None, None]:
+        """Generate interstitials.
+
+        Args:
+            chgcar: The chgcar object to be used for the charge density.
+            insert_species: The species to be inserted.
+            **kwargs: Additional keyword arguments for the ``Interstitial`` constructor.
+        """
+        cand_sites = self._get_candidate_sites(chgcar)
+        for species in insert_species:
+            yield from InterstitialGenerator.get_defects(
+                self, chgcar.structure, {species: cand_sites}
+            )
+
+    def _get_candidate_sites(self, chgcar: Chgcar):
+        cia = ChargeInsertionAnalyzer(
+            chgcar,
+            clustering_tol=self.clustering_tol,
+            ltol=self.ltol,
+            stol=self.stol,
+            angle_tol=self.angle_tol,
+            min_dist=self.min_dist,
+        )
+        avg_chg_groups = cia.filter_and_group(
+            avg_radius=self.avg_radius, max_avg_charge=self.max_avg_charge
+        )
+        for _, g in avg_chg_groups:
+            yield g[0]
 
 
 def _element_str(sp_or_el: Species | Element) -> str:
@@ -269,3 +329,9 @@ def _element_str(sp_or_el: Species | Element) -> str:
         return str(sp_or_el)
     else:
         raise ValueError(f"{sp_or_el} is not a species or element")
+
+
+def _remove_oxidation_states(structure: Structure) -> Structure:
+    struct = structure.copy()
+    struct.remove_oxidation_states()
+    return struct

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -296,7 +296,7 @@ def get_local_extrema(chgcar: VolumetricData, find_min: bool = True) -> npt.NDAr
 
 
 def remove_collisions(
-    fcoords: npt.NDArray, structure: Structure, min_dist: float = 0.5
+    fcoords: npt.NDArray, structure: Structure, min_dist: float = 0.9
 ) -> npt.NDArray:
     """
     Removed points that are too close to existing atoms in the structure
@@ -425,7 +425,7 @@ class ChargeInsertionAnalyzer(MSONable):
         ltol: float = 0.2,
         stol: float = 0.3,
         angle_tol: float = 5,
-        min_dist: float = 0.5,
+        min_dist: float = 0.9,
     ):
         """
         Args:
@@ -435,7 +435,7 @@ class ChargeInsertionAnalyzer(MSONable):
             ltol: StructureMatcher ltol parameter
             stol: StructureMatcher stol parameter
             angle_tol: StructureMatcher angle_tol parameter
-            min_dist: Minimum distance between sites and the host atoms.
+            min_dist: Minimum distance between sites and the host atoms in Å.
         """
         self.chgcar = chgcar
         self.working_ion = working_ion

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pymatgen.analysis.defects.core import Interstitial, Substitution, Vacancy
+from pymatgen.analysis.defects.core import Substitution, Vacancy
 from pymatgen.analysis.defects.generators import (
     AntiSiteGenerator,
     InterstitialGenerator,
@@ -10,11 +10,11 @@ from pymatgen.analysis.defects.generators import (
 
 
 def test_vacancy_generators(gan_struct):
-    vacancy_generator = VacancyGenerator(gan_struct)
+    vacancy_generator = VacancyGenerator().get_defects(gan_struct)
     for defect in vacancy_generator:
         assert isinstance(defect, Vacancy)
 
-    vacancy_generator = VacancyGenerator(gan_struct, ["Ga"])
+    vacancy_generator = VacancyGenerator().get_defects(gan_struct, ["Ga"])
     cnt = 0
     for defect in vacancy_generator:
         assert isinstance(defect, Vacancy)
@@ -22,11 +22,15 @@ def test_vacancy_generators(gan_struct):
     assert cnt == 1
 
     with pytest.raises(ValueError):
-        vacancy_generator = VacancyGenerator(gan_struct, ["Xe"])
+        vacancy_generator = list(
+            VacancyGenerator().get_defects(gan_struct, rm_species=["Xe"])
+        )
 
 
 def test_substitution_generators(gan_struct):
-    sub_generator = SubstitutionGenerator(gan_struct, {"Ga": ["Mg", "Ca"]})
+    sub_generator = SubstitutionGenerator().get_defects(
+        gan_struct, {"Ga": ["Mg", "Ca"]}
+    )
     replaced_atoms = set()
     for defect in sub_generator:
         assert isinstance(defect, Substitution)
@@ -35,16 +39,32 @@ def test_substitution_generators(gan_struct):
 
 
 def test_antisite_generator(gan_struct):
-    anti_gen = AntiSiteGenerator(gan_struct)
+    anti_gen = AntiSiteGenerator().get_defects(gan_struct)
     def_names = [defect.name for defect in anti_gen]
     assert sorted(def_names) == ["Ga_N", "N_Ga"]
 
 
-def test_interstitial_generator(chgcar_fe3o4):
-    gen = InterstitialGenerator.from_chgcar(chgcar_fe3o4, "Ga", max_avg_charge=0.5)
-    cnt = 0
-    for defect in gen:
-        assert isinstance(defect, Interstitial)
-        assert defect.site.specie.symbol == "Ga"
-        cnt += 1
-    assert cnt == 2
+def test_interstitial_generator(gan_struct, chgcar_fe3o4):
+    gen = InterstitialGenerator().get_defects(
+        gan_struct, insertions={"Mg": [[0, 0, 0]]}
+    )
+    l_gen = list(gen)
+    assert len(l_gen) == 1
+    assert str(l_gen[0]) == "Mg intersitial site at at site [0.00,0.00,0.00]"
+
+    bad_site = [0.667, 0.333, 0.875]
+    gen = InterstitialGenerator().get_defects(
+        gan_struct, insertions={"Mg": [[0, 0, 0], bad_site]}
+    )
+    l_gen = list(gen)
+    assert len(l_gen) == 1
+
+
+# def test_interstitial_generator(chgcar_fe3o4):
+#     gen = InterstitialGenerator.from_chgcar(chgcar_fe3o4, "Ga", max_avg_charge=0.5)
+#     cnt = 0
+#     for defect in gen:
+#         assert isinstance(defect, Interstitial)
+#         assert defect.site.specie.symbol == "Ga"
+#         cnt += 1
+#     assert cnt == 2

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,8 +1,9 @@
 import pytest
 
-from pymatgen.analysis.defects.core import Substitution, Vacancy
+from pymatgen.analysis.defects.core import Interstitial, Substitution, Vacancy
 from pymatgen.analysis.defects.generators import (
     AntiSiteGenerator,
+    ChargeInterstitialGenerator,
     InterstitialGenerator,
     SubstitutionGenerator,
     VacancyGenerator,
@@ -44,7 +45,7 @@ def test_antisite_generator(gan_struct):
     assert sorted(def_names) == ["Ga_N", "N_Ga"]
 
 
-def test_interstitial_generator(gan_struct, chgcar_fe3o4):
+def test_interstitial_generator(gan_struct):
     gen = InterstitialGenerator().get_defects(
         gan_struct, insertions={"Mg": [[0, 0, 0]]}
     )
@@ -60,11 +61,11 @@ def test_interstitial_generator(gan_struct, chgcar_fe3o4):
     assert len(l_gen) == 1
 
 
-# def test_interstitial_generator(chgcar_fe3o4):
-#     gen = InterstitialGenerator.from_chgcar(chgcar_fe3o4, "Ga", max_avg_charge=0.5)
-#     cnt = 0
-#     for defect in gen:
-#         assert isinstance(defect, Interstitial)
-#         assert defect.site.specie.symbol == "Ga"
-#         cnt += 1
-#     assert cnt == 2
+def test_charge_interstitial_generator(chgcar_fe3o4):
+    gen = ChargeInterstitialGenerator().get_defects(chgcar_fe3o4, {"Ga"})
+    cnt = 0
+    for defect in gen:
+        assert isinstance(defect, Interstitial)
+        assert defect.site.specie.symbol == "Ga"
+        cnt += 1
+    assert cnt == 2

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -267,7 +267,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('mp')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.4"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
# Refactor Generators
- The generators themselves should only define the tolerances
- each one should have a `get_defects` function that reads in a structure/charge density and yields defect objects
