### PR TITLE
Fix typo in quickstart pip install command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,4 +78,4 @@ repos:
   rev: 0.6.0
   hooks:
     - id: nbstripout
-      args: ["--keep-output"]
+      args: [--keep-output, --drop-empty-cells]

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "## Installation\n",
     "\n",
-    "The package can be installed from PyPI using `pip install pymatgen-analysis-defect`. \n",
+    "The package can be installed from PyPI using `pip install pymatgen-analysis-defects`. \n",
     "\n",
     "Once installed, the different modules can be imported via the `pymatgen.analysis.defects` namespace.\n",
     "\n",

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -256,13 +256,6 @@
     "plt.xlabel(\"Fermi Level (eV)\")\n",
     "plt.ylabel(\"Formation Energy(eV)\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Stumbled over this error after copy pasting the `pip` command from [the docs](https://materialsproject.github.io/pymatgen-analysis-defects/tutorials/1-quickstart.html#Installation)

> "The package can be installed from PyPI using `pip install pymatgen-analysis-defect`."

```
ERROR: No matching distribution found for pymatgen-analysis-defect
```