### PR TITLE
Defect Objects

### DIFF
--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -264,6 +264,22 @@ class Vacancy(Defect):
         return f"{vac_species} Vacancy defect at site #{self.defect_site_index}"
 
 
+class GhostVacancy(Vacancy):
+    """
+    Alternate definition of vacancy for simulation packages using a localized basis.
+    Vacancies are normally just structures with an atom removed, but with a local basis
+    we retain the site and turn off its interaction potential (Ghost atom) in order to 
+    avoid Basis set superposition error.
+    """
+
+    @property
+    def defect_structure(self):
+        """Returns the defect structure with the proper oxidation state"""
+        struct = self.structure.copy()
+        struct.add_site_property("ghost", [i == self.defect_site_index for i in range(len(struct))])
+        return struct
+
+
 class Substitution(Defect):
     """Single-site substitutional defects."""
 
@@ -464,6 +480,20 @@ class Interstitial(Defect):
         sub_species = get_element(self.site.specie)
         fpos_str = ",".join(f"{x:.2f}" for x in self.site.frac_coords)
         return f"{sub_species} intersitial site at " f"at site [{fpos_str}]"
+
+
+class Adsorbate(Interstitial):
+    """
+    Subclass of Interstitial with a different name. Used for keeping track of adsorbate, which are
+    treated the same algorithmically as interstitials, but are conceptually separate.
+    """
+
+    @property
+    def name(self) -> str:
+        """
+        Returns a name for this defect
+        """
+        return "{}_\{ads\}".format(get_element(self.site.specie))
 
 
 def get_element(sp_el: Species | Element) -> Element:


### PR DESCRIPTION
Small Adjustment to core defect definitions.

GhostVacancy is very important variant on the Vacancy class which makes vacancy calculations possible in codes with a localized basis set.

Adsorbate is not required, but I have found it useful to define an adsorbate as something akin to but different than an interstitial object. Adsorbates can be treated as defects in 2d cases.