### PR TITLE
fixed buggy constructor when providing user inputs

### DIFF
--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -181,7 +181,7 @@ class HarmonicDefect(MSONable):
             bs = None
 
         if defect_band_index is None:
-            if procar is None:
+            if procar is None:  # pragma: no cover
                 raise ValueError(
                     "If defect_band_index is not provided, you must provide a Procar object."
                 )
@@ -194,7 +194,7 @@ class HarmonicDefect(MSONable):
                 raise ValueError(
                     "If ``defect_band_index`` is provided, you must provide also ``spin_index``."
                 )
-            if kpt_index is None:
+            if kpt_index is None:  # pragma: no cover
                 raise ValueError(
                     "If ``defect_band_index`` is provided, you must provide also ``kpt_index``."
                 )

--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -171,25 +171,36 @@ class HarmonicDefect(MSONable):
             E0=energies[relaxed_index],
         )
 
+        get_band_structure_kwargs = get_band_structure_kwargs or {}
+        bandstructure = vaspruns[relaxed_index].get_band_structure(
+            **get_band_structure_kwargs
+        )
+        if store_bandstructure:
+            bs = bandstructure
+        else:
+            bs = None
+
         if defect_band_index is None:
             if procar is None:
                 raise ValueError(
                     "If defect_band_index is not provided, you must provide a Procar object."
                 )
-            get_band_structure_kwargs = get_band_structure_kwargs or {}
-            bandstructure = vaspruns[relaxed_index].get_band_structure(
-                **get_band_structure_kwargs
+            loc_res = get_localized_state(
+                bandstructure=bandstructure, procar=procar, k_index=kpt_index
             )
-            loc_res = get_localized_state(bandstructure=bandstructure, procar=procar)
             spin_e, (_, defect_band_index) = min(loc_res.items(), key=lambda x: x[1])
+        else:
+            if spin_index is None:
+                raise ValueError(
+                    "If ``defect_band_index`` is provided, you must provide also ``spin_index``."
+                )
+            if kpt_index is None:
+                raise ValueError(
+                    "If ``defect_band_index`` is provided, you must provide also ``kpt_index``."
+                )
 
         if spin_index is None:
             spin_index = 0 if spin_e == Spin.up else 1
-
-        if store_bandstructure:
-            bs = bandstructure
-        else:
-            bs = None
 
         return cls(
             omega=omega,
@@ -580,7 +591,9 @@ class SRHCapture(MSONable):
             **kwargs,
         )
         wswq_files = [f for f in wswq_dir.glob("WSWQ*")]
-        wswq_files.sort(key=lambda x: int(x.stem.split(".")[1]))
+        wswq_files.sort(
+            key=lambda x: int(x.stem.split(".")[1])
+        )  # does stem work for non-zipped files?
         wswqs = [WSWQ.from_file(f) for f in wswq_files]
         dQ = get_dQ(initial_defect.relaxed_structure, final_defect.relaxed_structure)
         return cls(initial_defect, final_defect, dQ=dQ, wswqs=wswqs)

--- a/tests/test_ccd.py
+++ b/tests/test_ccd.py
@@ -29,6 +29,22 @@ def test_HarmonicDefect(v_ga):
     assert np.allclose(elph_me[..., 138], 0.0)  # ediff should be zero for defect band
     assert np.linalg.norm(elph_me[..., 139]) > 0
 
+    hd2 = HarmonicDefect.from_vaspruns(
+        vaspruns,
+        charge_state=0,
+        procar=procar,
+        kpt_index=1,
+        defect_band_index=139,
+        spin_index=1,
+    )
+    hd2.spin_index == 1
+
+    # check for ValueError
+    with pytest.raises(ValueError):
+        HarmonicDefect.from_vaspruns(
+            vaspruns, charge_state=0, procar=procar, kpt_index=1, defect_band_index=139
+        )
+
 
 # def test_OpticalHarmonicDefect(v_ga):
 #     from pymatgen.analysis.defects.ccd import OpticalHarmonicDefect


### PR DESCRIPTION
# fixed buggy `HarmonicDefect` constructor

The new behavior is:  if you specify the defect_band_index, it means you know which defect you want and you have provide all the other indices.
