### PR TITLE
Store correction summary on the DefectEntry

### DIFF
--- a/pymatgen/analysis/defects/corrections.py
+++ b/pymatgen/analysis/defects/corrections.py
@@ -35,7 +35,7 @@ Rewritten to be functional instead of object oriented.
 """
 
 
-def get_correction(
+def get_freysoldt_correction(
     q: int,
     dielectric: float,
     defect_locpot: Locpot,

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -46,6 +46,10 @@ class DefectEntry(MSONable):
             automatically determine the defect location.
         corrections:
             A dictionary of corrections to the energy.
+        correction_summaries:
+            A dictionary that acts as a generic container for storing information
+            about how the corrections were calculated.  These should are only used
+            for debugging and plotting purposes.
     """
 
     defect: Defect
@@ -53,6 +57,7 @@ class DefectEntry(MSONable):
     sc_entry: ComputedStructureEntry
     sc_defect_frac_coords: Optional[ArrayLike] = None
     corrections: Optional[Dict[str, float]] = None
+    corrections_summaries: Optional[Dict[str, Dict]] = None
 
     def __post_init__(self):
         """Post-initialization."""
@@ -105,8 +110,8 @@ class DefectEntry(MSONable):
             defect_frac_coords=defect_fpos,
             **kwargs,
         )
-
         self.corrections.update(frey_corr)  # type: ignore
+        self.corrections_summaries["frey_corr"] = plot_data
         return plot_data
 
     @property

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -17,7 +17,7 @@ from pymatgen.io.vasp import Locpot, Vasprun
 from scipy.spatial import ConvexHull
 
 from pymatgen.analysis.defects.core import Defect
-from pymatgen.analysis.defects.corrections import get_correction
+from pymatgen.analysis.defects.corrections import get_freysoldt_correction
 from pymatgen.analysis.defects.finder import DefectSiteFinder
 from pymatgen.analysis.defects.utils import get_zfile
 
@@ -63,6 +63,9 @@ class DefectEntry(MSONable):
         """Post-initialization."""
         self.charge_state = int(self.charge_state)
         self.corrections: dict = {} if self.corrections is None else self.corrections
+        self.corrections_summaries: dict = (
+            {} if self.corrections_summaries is None else self.corrections_summaries
+        )
 
     def get_freysoldt_correction(
         self,
@@ -102,7 +105,7 @@ class DefectEntry(MSONable):
         else:
             defect_fpos = self.sc_defect_frac_coords
 
-        frey_corr, plot_data = get_correction(
+        frey_corr, plot_data = get_freysoldt_correction(
             q=self.charge_state,
             dielectric=dielectric,
             defect_locpot=defect_locpot,
@@ -111,7 +114,7 @@ class DefectEntry(MSONable):
             **kwargs,
         )
         self.corrections.update(frey_corr)  # type: ignore
-        self.corrections_summaries["frey_corr"] = plot_data
+        self.corrections_summaries["freysoldt_corrections"] = plot_data.copy()
         return plot_data
 
     @property

--- a/tests/test_recombination.py
+++ b/tests/test_recombination.py
@@ -22,9 +22,10 @@ def test_boltzmann():
         3.901200631921917e-09,
     ]
     results = boltzmann_filling(0.1, 300, n_states=6)
-    assert np.testing.assert_allclose(results.flatten(), ref_results)
+    print(results.flatten())
+    assert np.allclose(results.flatten(), ref_results, rtol=1e-3)
     results2 = boltzmann_filling(0.1, [100, 300], n_states=6)
-    assert np.testing.assert_allclose(results2[:, 1], ref_results, rtol=1e-3)
+    assert np.allclose(results2[:, 1], ref_results, rtol=1e-3)
 
 
 def test_get_vibronic_matrix_elements():
@@ -49,7 +50,7 @@ def test_pchip_eval():
     fx = pchip_eval(xx, x_coarse=x_c, y_coarse=y_c)
     int_val = np.trapz(np.nan_to_num(fx), x=xx)
     int_ref = np.sum(y_c)
-    assert pytest.approx(int_val, int_ref)
+    assert int_val == pytest.approx(int_ref, rel=1e-3)
 
 
 def test_get_SRH_coef():

--- a/tests/test_recombination.py
+++ b/tests/test_recombination.py
@@ -22,9 +22,9 @@ def test_boltzmann():
         3.901200631921917e-09,
     ]
     results = boltzmann_filling(0.1, 300, n_states=6)
-    np.testing.assert_allclose(results.flatten(), ref_results)
+    assert np.testing.assert_allclose(results.flatten(), ref_results)
     results2 = boltzmann_filling(0.1, [100, 300], n_states=6)
-    np.testing.assert_allclose(results2[:, 1], ref_results)
+    assert np.testing.assert_allclose(results2[:, 1], ref_results, rtol=1e-3)
 
 
 def test_get_vibronic_matrix_elements():
@@ -39,7 +39,7 @@ def test_get_vibronic_matrix_elements():
         omega_i=omega_i, omega_f=omega_f, m_init=0, Nf=Nf, dQ=dQ, ovl=ovl
     )
     ref_result = [0.0, 3984589.0407885523, 0.0, 0.0, 0.0]
-    np.allclose(matel, ref_result)
+    assert np.allclose(matel, ref_result)
 
 
 def test_pchip_eval():
@@ -49,7 +49,7 @@ def test_pchip_eval():
     fx = pchip_eval(xx, x_coarse=x_c, y_coarse=y_c)
     int_val = np.trapz(np.nan_to_num(fx), x=xx)
     int_ref = np.sum(y_c)
-    pytest.approx(int_val, int_ref)
+    assert pytest.approx(int_val, int_ref)
 
 
 def test_get_SRH_coef():
@@ -64,4 +64,4 @@ def test_get_SRH_coef():
         volume=1,
         g=1,
     )
-    np.allclose(res, ref_res)
+    assert np.allclose(res, ref_res)

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -27,7 +27,7 @@ def test_lower_envelope():
     ]
 
 
-def test_defect_entry2(defect_entries_Mg_Ga):
+def test_defect_entry(defect_entries_Mg_Ga):
     defect_entries, plot_data = defect_entries_Mg_Ga
 
     def_entry = defect_entries[0]
@@ -48,6 +48,13 @@ def test_defect_entry2(defect_entries_Mg_Ga):
 
     # test that the plotting code runs
     plot_plnr_avg(plot_data[0][1])
+    plot_plnr_avg(defect_entries[1].corrections_summaries["freysoldt_corrections"][1])
+
+    vr1 = plot_data[0][1]["pot_plot_data"]["Vr"]
+    vr2 = defect_entries[0].corrections_summaries["freysoldt_corrections"][1][
+        "pot_plot_data"
+    ]["Vr"]
+    assert np.allclose(vr1, vr2)
 
 
 def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga_N):


### PR DESCRIPTION
# Store correction summary and Test Fixes

## Correction sumary in `DefectEntry`
For post processing and and analysis convenience, we should store the summary result of the correction function (like he plot data for the freysoldt correction) on the defect entry itself.
These intermediate results should no be too big.

## Test fixes
A couple of test were missing `assert` before `np.allclose` so they were not actually testing. 


Breaking:
- renamed `get_correction` to `get_freysoldt_correction`