### PR TITLE
Allow access to inverse participation ration in a window

### DIFF
--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -188,7 +188,7 @@ class HarmonicDefect(MSONable):
             loc_res = get_localized_state(
                 bandstructure=bandstructure, procar=procar, k_index=kpt_index
             )
-            spin_e, (_, defect_band_index) = min(loc_res.items(), key=lambda x: x[1])
+            spin_e, (defect_band_index, _) = min(loc_res.items(), key=lambda x: x[1])
         else:
             if spin_index is None:
                 raise ValueError(

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -596,7 +596,7 @@ def get_localized_state(
             k_index = 0
         # find the index of the minimum IPR
         min_idx = np.argmin(ib_ipr[k_index, :, 1])
-        if not ib_ipr[k_index, min_idx, 0].is_integer():
+        if not ib_ipr[k_index, min_idx, 0].is_integer():  # pragma: no cover
             raise ValueError(
                 "Since the band indices are synced across "
                 "different k points this should always be an integer."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_get_localized_states(v_ga):
     vr = vaspruns[1]
     bs = vr.get_band_structure()
     res = get_localized_state(bs, procar=procar)
-    _, (_, min_indx) = min(res.items(), key=lambda x: x[1])
+    _, (min_indx, _) = min(res.items(), key=lambda x: x[1])
     assert min_indx == 138
 
     vaspruns = v_ga[(-1, 0)]["vaspruns"]
@@ -85,4 +85,13 @@ def test_get_localized_states(v_ga):
     vr = vaspruns[1]
     bs = vr.get_band_structure()
     res = get_localized_state(bs, procar=procar)
+    _, (min_indx, _) = min(res.items(), key=lambda x: x[1])
     assert min_indx == 138
+
+    res = get_localized_state(bs, procar=procar, k_index=0)
+    _, (min_indx, _) = min(res.items(), key=lambda x: x[1])
+    assert min_indx == 138
+
+    res = get_localized_state(bs, procar=procar, k_index=0, band_window=100)
+    _, (min_indx, _) = min(res.items(), key=lambda x: x[1])
+    assert min_indx < 138  # some core states should be more localized


### PR DESCRIPTION
# Allow access to inverse participation ratio in a window

During testing, it was discovered that `get_localized_state` is not super accurate and still requires user intervention.  So we need to be able to see the IPR data.

`get_localized_state` now computes all the IPR in a window first via the `get_ipr_in_window` function.  Then it finds the most localized one in each spin channel.