### PR TITLE
Update thermo.py

### DIFF
--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -238,9 +238,6 @@ class FormationEnergyDiagram(MSONable):
             self._chempot_limits_arr = chempot_limits[
                 ~np.any(chempot_limits == boundary_value, axis=1)
             ]
-        self._chempot_limits_arr = self._chempot_limits_arr.dot(
-            1 / self.bulk_entry.composition.reduced_composition.num_atoms
-        )
 
         self.dft_energies = {
             el: self.phase_diagram.get_hull_energy_per_atom(Composition(str(el)))


### PR DESCRIPTION
This modification looked right at first pass, but I think it was actually wrong.

Gave correct results on a test case because lit. defect values use no corrections, and dividing happened to make the corrected results match the uncorrected results.