### PR TITLE
[WIP] Corrections Schema

### DIFF
--- a/pymatgen/analysis/defects/corrections/base.py
+++ b/pymatgen/analysis/defects/corrections/base.py
@@ -1,8 +1,9 @@
 """Objects for representing corrections to defect calculations."""
 
-from typing import Any, Optional
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Optional
+
 import numpy as np
 from monty.json import MSONable
 
@@ -12,7 +13,6 @@ class CorrectionType(Enum):
 
     ELECTROSTATIC = "electrostatic"
     POTENTIAL_ALIGNMENT = "potential_alignment"
-
 
 
 @dataclass

--- a/pymatgen/analysis/defects/corrections/base.py
+++ b/pymatgen/analysis/defects/corrections/base.py
@@ -1,0 +1,65 @@
+from typing import Any, Optional
+from dataclasses import dataclass
+from enum import Enum
+from monty.json import MSONable
+
+
+class CorrectionType(Enum):
+    """Correction type"""
+    electrostatic = "electrostatic"
+    potential_alignment = "potential_alignment"
+
+@dataclass
+class Correction(MSONable):
+    """Summary of a single energy correction
+
+    Attributes:
+        correction_energy: float
+        correction_type: CorrectionType
+        metadata: any metadata (generally used to store pot align plot data)
+    """
+
+    correction_energy: float
+    correction_type: CorrectionType
+    uncertainty: float = None,
+    name: str = "Defect correction",
+    description: str = "",
+    metadata: Optional[dict[Any, Any]] = None
+
+    def __post_init__(self):
+        self.metadata: dict = {} if self.metadata is None else self.metadata
+
+@dataclass
+class CorrectionsSummary(MSONable):
+    """A summary of all defect corrections applied to a structure.
+
+    Attributes:
+        corrections: A dictionary mapping CorrectionType to its correction energy
+        metadata: A dictionary of metadata for plotting and intermediate analysis.
+    """
+    corrections: dict[CorrectionType, float]
+    metadata: dict[Any, Any]
+
+    @property
+    def correction_energy(self):
+        """Get total correction energy"""
+        return sum(self.corrections.values())
+
+    @classmethod
+    def from_corrections(cls, corrections: list[Correction]):
+        """Join many corrections. If many corrections of
+        the same type are present, only the last will be
+        included.
+
+        Parameters
+        -------------
+
+        corrections
+            List of Corrections.
+        """
+        corrs = {}
+        metadata = {}
+        for c in corrections:
+            corrs.update({c.correction_type: c.correction_energy})
+            metadata.update(c.metadata)
+        return CorrectionsSummary(corrs, metadata)

--- a/pymatgen/analysis/defects/corrections/base.py
+++ b/pymatgen/analysis/defects/corrections/base.py
@@ -1,65 +1,75 @@
+"""Objects for representing corrections to defect calculations."""
+
 from typing import Any, Optional
 from dataclasses import dataclass
 from enum import Enum
+import numpy as np
 from monty.json import MSONable
 
 
 class CorrectionType(Enum):
-    """Correction type"""
-    electrostatic = "electrostatic"
-    potential_alignment = "potential_alignment"
+    """Correction type."""
+
+    ELECTROSTATIC = "electrostatic"
+    POTENTIAL_ALIGNMENT = "potential_alignment"
+
 
 @dataclass
 class Correction(MSONable):
-    """Summary of a single energy correction
+    """Summary of a single energy correction.
 
-    Attributes:
-        correction_energy: float
-        correction_type: CorrectionType
-        metadata: any metadata (generally used to store pot align plot data)
+    Parameters
+    -------------
+        correction_energy
+            energy (in eV) of the correction
+        correction_type
+            Enum for the type of correction
+        metadata
+            Any metadata for this correction
     """
 
     correction_energy: float
     correction_type: CorrectionType
-    uncertainty: float = None,
-    name: str = "Defect correction",
-    description: str = "",
+    uncertainty: float = np.nan
+    name: str = "Defect correction"
+    description: str = ""
     metadata: Optional[dict[Any, Any]] = None
 
     def __post_init__(self):
+        """Post initialization modifications."""
         self.metadata: dict = {} if self.metadata is None else self.metadata
+
 
 @dataclass
 class CorrectionsSummary(MSONable):
     """A summary of all defect corrections applied to a structure.
 
-    Attributes:
-        corrections: A dictionary mapping CorrectionType to its correction energy
-        metadata: A dictionary of metadata for plotting and intermediate analysis.
+    Parameters
+    -------------
+        corrections
+            A dictionary mapping CorrectionType to its correction energy
+        metadata
+            A dictionary of metadata for plotting and intermediate analysis.
     """
+
     corrections: dict[CorrectionType, float]
     metadata: dict[Any, Any]
 
     @property
     def correction_energy(self):
-        """Get total correction energy"""
+        """Get total correction energy."""
         return sum(self.corrections.values())
 
     @classmethod
     def from_corrections(cls, corrections: list[Correction]):
-        """Join many corrections. If many corrections of
-        the same type are present, only the last will be
-        included.
+        """Join many corrections.
 
-        Parameters
-        -------------
-
-        corrections
-            List of Corrections.
+        Args:
+            corrections: List of Corrections.
         """
         corrs = {}
         metadata = {}
-        for c in corrections:
-            corrs.update({c.correction_type: c.correction_energy})
-            metadata.update(c.metadata)
+        for corr in corrections:
+            corrs.update({corr.correction_type: corr.correction_energy})
+            metadata.update(corr.metadata)
         return CorrectionsSummary(corrs, metadata)

--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -198,7 +198,7 @@ def perform_es_corr(
     es_corr = round((eiso - eper) / dielectric * hart_to_ev, 6)
     _logger.info("Defect Correction without alignment %f (eV): ", es_corr)
     return Correction(
-        correction_energy=es_corr, correction_type=CorrectionType.electrostatic,
+        correction_energy=es_corr, correction_type=CorrectionType.ELECTROSTATIC,
         name="Freysoldt electrostatic",
         description="https://doi.org/10.1103/PhysRevLett.102.016402"
         )
@@ -235,7 +235,7 @@ def perform_pot_corr(
         correction_energy=pot_corr if q else 0,
         name="Freysoldt potential alignment",
         description="https://doi.org/10.1103/PhysRevLett.102.016402",
-        correction_type=CorrectionType.potential_alignment,
+        correction_type=CorrectionType.POTENTIAL_ALIGNMENT,
         metadata=plot_data,
         )
 

--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -201,7 +201,8 @@ def perform_es_corr(
     es_corr = round((eiso - eper) / dielectric * hart_to_ev, 6)
     _logger.info("Defect Correction without alignment %f (eV): ", es_corr)
     return Correction(
-        correction_energy=es_corr, correction_type=CorrectionType.ELECTROSTATIC,
+        correction_energy=es_corr,
+        correction_type=CorrectionType.ELECTROSTATIC,
         name="Freysoldt electrostatic",
         description="https://doi.org/10.1103/PhysRevLett.102.016402",
     )

--- a/pymatgen/analysis/defects/corrections/kumagai.py
+++ b/pymatgen/analysis/defects/corrections/kumagai.py
@@ -116,7 +116,7 @@ def get_efnv_correction(
     es_corr = Correction(
         correction_energy=efnv_corr.point_charge_correction,
         correction_type=CorrectionType.ELECTROSTATIC,
-        )
+    )
 
     # TODO Need to get potalign plot data
     pot_corr = Correction(

--- a/pymatgen/analysis/defects/corrections/kumagai.py
+++ b/pymatgen/analysis/defects/corrections/kumagai.py
@@ -111,13 +111,13 @@ def get_efnv_correction(
 
     es_corr = Correction(
         correction_energy=efnv_corr.point_charge_correction,
-        correction_type=CorrectionType.electrostatic,
+        correction_type=CorrectionType.ELECTROSTATIC,
         )
 
     # TODO Need to get potalign plot data
     pot_corr = Correction(
         correction_energy=efnv_corr.alignment_correction,
-        correction_type=CorrectionType.potential_alignment,
+        correction_type=CorrectionType.POTENTIAL_ALIGNMENT,
     )
 
     return CorrectionsSummary.from_corrections([es_corr, pot_corr])

--- a/pymatgen/analysis/defects/corrections/kumagai.py
+++ b/pymatgen/analysis/defects/corrections/kumagai.py
@@ -100,6 +100,7 @@ def get_efnv_correction(
         potentials=bulk_potentials,
     )
 
+    # TODO Should probably be done natively instead of with pydefect
     efnv_corr = make_efnv_correction(
         charge=charge,
         calc_results=defect_calc_results,
@@ -108,10 +109,15 @@ def get_efnv_correction(
         **kwargs,
     )
 
-    # TODO Using pydefect
-    efnv_corr = Correction(
-        correction_energy=efnv_corr.correction_energy,
+    es_corr = Correction(
+        correction_energy=efnv_corr.point_charge_correction,
         correction_type=CorrectionType.electrostatic,
-        metadata={"efnv_corr": efnv_corr}
         )
-    return CorrectionsSummary.from_corrections([efnv_corr])
+
+    # TODO Need to get potalign plot data
+    pot_corr = Correction(
+        correction_energy=efnv_corr.alignment_correction,
+        correction_type=CorrectionType.potential_alignment,
+    )
+
+    return CorrectionsSummary.from_corrections([es_corr, pot_corr])

--- a/pymatgen/analysis/defects/corrections/kumagai.py
+++ b/pymatgen/analysis/defects/corrections/kumagai.py
@@ -10,7 +10,8 @@ import logging
 import math
 from pathlib import Path
 
-from pymatgen.analysis.defects.utils import CorrectionResult, get_zfile
+from pymatgen.analysis.defects.corrections.base import CorrectionType, Correction, CorrectionsSummary
+from pymatgen.analysis.defects.utils import get_zfile
 
 # check that pydefect is installed
 try:
@@ -72,7 +73,7 @@ def get_efnv_correction(
     bulk_structure: Structure,
     dielectric_tensor: list[list[float]],
     **kwargs,
-) -> CorrectionResult:
+) -> CorrectionsSummary:
     """Returns the Kumagai/Oba EFNV correction for a given defect.
 
     Args:
@@ -107,6 +108,10 @@ def get_efnv_correction(
         **kwargs,
     )
 
-    return CorrectionResult(
-        correction_energy=efnv_corr.correction_energy, metadata={"efnv_corr": efnv_corr}
-    )
+    # TODO Using pydefect
+    efnv_corr = Correction(
+        correction_energy=efnv_corr.correction_energy,
+        correction_type=CorrectionType.electrostatic,
+        metadata={"efnv_corr": efnv_corr}
+        )
+    return CorrectionsSummary.from_corrections([efnv_corr])

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -970,17 +970,3 @@ def get_symmetry_labeled_structures(
     # Label the groups by structure matching
     site_labels = generic_groupby(inserted_structs, comp=sm.fit)
     return [*zip(sites.tolist(), site_labels)]
-
-
-@dataclass
-class CorrectionResult(MSONable):
-    """A summary of the corrections applied to a structure.
-
-    Attributes:
-        electrostatic: The electrostatic correction.
-        potential_alignment: The potential alignment correction.
-        metadata: A dictionary of metadata for plotting and intermediate analysis.
-    """
-
-    correction_energy: float
-    metadata: dict[Any, Any]

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -42,20 +42,20 @@ def test_defect_entry(defect_entries_Mg_Ga):
     defect_entries, plot_data = defect_entries_Mg_Ga
 
     def_entry = defect_entries[0]
-    assert def_entry.corrections["freysoldt"] == pytest.approx(0.00, abs=1e-4)
+    assert def_entry.corrections.correction_energy == pytest.approx(0.00, abs=1e-4)
 
     def_entry = defect_entries[-2]
-    assert def_entry.corrections["freysoldt"] > 0
+    assert def_entry.corrections.correction_energy > 0
 
     def_entry = defect_entries[1]
-    assert def_entry.corrections["freysoldt"] > 0
+    assert def_entry.corrections.correction_energy > 0
 
     # test that the plotting code runs
     plot_plnr_avg(plot_data[0][1])
-    plot_plnr_avg(defect_entries[1].correction_metadata["freysoldt"][1])
+    plot_plnr_avg(defect_entries[1].corrections.metadata[1])
 
     vr1 = plot_data[0][1]["pot_plot_data"]["Vr"]
-    vr2 = defect_entries[0].correction_metadata["freysoldt"][1]["pot_plot_data"]["Vr"]
+    vr2 = defect_entries[0].corrections.metadata[1]["pot_plot_data"]["Vr"]
     assert np.allclose(vr1, vr2)
 
 


### PR DESCRIPTION
We need a method for dealing with the compatibility of different defect corrections. i.e. the corrected energy should not include multiple electrostatic corrections or multiple potential alignment corrections.

The best way to do deal with this, imo, is to have new correction objects that handle it. The current `DefectEntry` hard codes "freysoldt" for getting corrections, but one might want to use eFNV or the 2D-FNV correction.

Current idea is to define each correction with a `Correction` object that holds energy and metadata, and then a `DefectEntry` holds a `CorrectionSummary` which holds multiple corrections, mapped with a dictionary of `CorrectionType`. This way, if you try to add, say, a eFNV correction, it will replace the FNV correction in the dict.