### PR TITLE
Added bulk entry to DefectEntry

### DIFF
--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -367,7 +367,6 @@ class FormationEnergyDiagram(MSONable):
                 defect_locpot=q_locpot, bulk_locpot=bulk_locpot, dielectric=dielectric
             )
             def_entries.append(q_d_entry)
-
         if vbm is None:
             vr = Vasprun(get_zfile(Path(directory_map["bulk"]), "vasprun.xml"))
             vbm = vr.get_band_structure().get_vbm()["energy"]

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -216,7 +216,7 @@ class FormationEnergyDiagram(MSONable):
                 "Use MultiFormationEnergyDiagram for multiple defect types"
             )
         # if all of the `DefectEntry` objects have the same `bulk_entry` then `self.bulk_entry` is not needed
-        if all(hasattr(d, "bulk_entry") for d in self.defect_entries):
+        if all(d.bulk_entry is not None for d in self.defect_entries):
             if self.bulk_entry is not None:
                 raise ValueError(
                     "All of the `DefectEntry` objects have a `bulk_entry` attribute, it is not needed to provide `bulk_entry` to `FormationEnergyDiagram`"

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -218,9 +218,14 @@ class FormationEnergyDiagram(MSONable):
         # if all of the `DefectEntry` objects have the same `bulk_entry` then `self.bulk_entry` is not needed
         if all(d.bulk_entry is not None for d in self.defect_entries):
             if self.bulk_entry is not None:
-                raise ValueError(
+                raise RuntimeError(
                     "All of the `DefectEntry` objects have a `bulk_entry` attribute, it is not needed to provide `bulk_entry` to `FormationEnergyDiagram`"
                     "The energy difference E[Defect SuperCell] - E[Bulk SuperCell] can be calculated directly from `DefectEntry.get_ediff`."
+                )
+        else:
+            if self.bulk_entry is None:
+                raise RuntimeError(
+                    "Not all of the `DefectEntry` objects have a `bulk_entry` attribute, you need to provide `bulk_entry` to `FormationEnergyDiagram`"
                 )
 
         bulk_entry = self.bulk_entry or self.defect_entries[0].bulk_entry
@@ -619,7 +624,10 @@ class MultiFormationEnergyDiagram(MSONable):
 
 
 def group_defects(defect_entries: list[DefectEntry]):
-    """Group defects by their representation."""
+    """Group defects by their representation.
+
+    TODO: Fix this with `defect_structure` grouping with `StructureMatcher`.
+    """
     sents = sorted(defect_entries, key=lambda x: x.defect.__repr__())
     for k, group in groupby(sents, key=lambda x: x.defect.__repr__()):
         yield k, list(group)

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import numpy as np
@@ -76,6 +77,36 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
         inc_inf_values=True,
     )
     assert len(fed.chempot_limits) == 5
+
+    # check that the constructor raises an error if `bulk_entry` is is provided for all defect entries
+    def_ents_w_bulk = copy.deepcopy(def_ent_list)
+    for dent in def_ents_w_bulk:
+        dent.bulk_entry = bulk_entry
+
+    fed = FormationEnergyDiagram(
+        defect_entries=def_ents_w_bulk,
+        vbm=vbm,
+        pd_entries=stable_entries_Mg_Ga_N,
+        inc_inf_values=True,
+    )
+    assert len(fed.chempot_limits) == 5
+
+    with pytest.raises(RuntimeError):
+        FormationEnergyDiagram(
+            bulk_entry=bulk_entry,
+            defect_entries=def_ents_w_bulk,
+            vbm=vbm,
+            pd_entries=stable_entries_Mg_Ga_N,
+            inc_inf_values=True,
+        )
+
+    with pytest.raises(RuntimeError):
+        FormationEnergyDiagram(
+            defect_entries=def_ent_list,
+            vbm=vbm,
+            pd_entries=stable_entries_Mg_Ga_N,
+            inc_inf_values=True,
+        )
 
     fed = FormationEnergyDiagram(
         bulk_entry=bulk_entry,

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -107,12 +107,12 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
     )
     pd = PhaseDiagram(stable_entries_Mg_Ga_N)
     fed = FormationEnergyDiagram.with_atomic_entries(
-        bulk_entry=bulk_entry,
         defect_entries=def_ent_list,
         atomic_entries=atomic_entries,
         vbm=vbm,
         inc_inf_values=False,
         phase_diagram=pd,
+        bulk_entry=bulk_entry,
     )
     assert len(fed.chempot_limits) == 3
 


### PR DESCRIPTION
We usually want to take the difference between E[DEFECT] - E[BULK] if the simualation cell of the defect changes, we can still compute this difference.

We can use very strict `task`-level matching to make sure each DEFECT is matched with the exact right bulk.  Then use the best `DefectEntry` to create the formation energy diagram.