### PR TITLE
Fixes for chargedensity insertion and DefectEntry

### DIFF
--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -169,8 +169,6 @@ class FormationEnergyDiagram(MSONable):
     """Formation energy.
 
     Attributes:
-        bulk_entry:
-            The bulk computed entry to get the total energy of the bulk supercell.
         defect_entries:
             The list of defect entries for the different charge states.
             The finite-size correction should already be applied to these.
@@ -183,6 +181,12 @@ class FormationEnergyDiagram(MSONable):
             The VBM of the bulk crystal.
         band_gap:
             The band gap of the bulk crystal.
+        bulk_entry:
+            The bulk computed entry to get the total energy of the bulk supercell.
+            This is only used in case where the bulk entry data is not provided by
+            the individual defect entries themselves. Default is None.
+            The data from the `bulk_entry` attached to each `defect_entry` will be
+            preferrentially used if it is available.
         inc_inf_values:
             If False these boundary points at infinity are ignored when we look at the
             chemical potential limits.
@@ -216,13 +220,7 @@ class FormationEnergyDiagram(MSONable):
                 "Use MultiFormationEnergyDiagram for multiple defect types"
             )
         # if all of the `DefectEntry` objects have the same `bulk_entry` then `self.bulk_entry` is not needed
-        if all(d.bulk_entry is not None for d in self.defect_entries):
-            if self.bulk_entry is not None:
-                raise RuntimeError(
-                    "All of the `DefectEntry` objects have a `bulk_entry` attribute, it is not needed to provide `bulk_entry` to `FormationEnergyDiagram`"
-                    "The energy difference E[Defect SuperCell] - E[Bulk SuperCell] can be calculated directly from `DefectEntry.get_ediff`."
-                )
-        else:
+        if any(d.bulk_entry is None for d in self.defect_entries):
             if self.bulk_entry is None:
                 raise RuntimeError(
                     "Not all of the `DefectEntry` objects have a `bulk_entry` attribute, you need to provide `bulk_entry` to `FormationEnergyDiagram`"

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -367,7 +367,6 @@ class FormationEnergyDiagram(MSONable):
                 defect_locpot=q_locpot, bulk_locpot=bulk_locpot, dielectric=dielectric
             )
             def_entries.append(q_d_entry)
-
         if vbm is None:
             vr = Vasprun(get_zfile(Path(directory_map["bulk"]), "vasprun.xml"))
             vbm = vr.get_band_structure().get_vbm()["energy"]

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -216,7 +216,7 @@ class FormationEnergyDiagram(MSONable):
                 "Use MultiFormationEnergyDiagram for multiple defect types"
             )
         # if all of the `DefectEntry` objects have the same `bulk_entry` then `self.bulk_entry` is not needed
-        if all(hasattr(d, "bulk_entry") for d in self.defect_entries):
+        if all(d.bulk_entry is not None for d in self.defect_entries):
             if self.bulk_entry is not None:
                 raise ValueError(
                     "All of the `DefectEntry` objects have a `bulk_entry` attribute, it is not needed to provide `bulk_entry` to `FormationEnergyDiagram`"

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -218,9 +218,14 @@ class FormationEnergyDiagram(MSONable):
         # if all of the `DefectEntry` objects have the same `bulk_entry` then `self.bulk_entry` is not needed
         if all(d.bulk_entry is not None for d in self.defect_entries):
             if self.bulk_entry is not None:
-                raise ValueError(
+                raise RuntimeError(
                     "All of the `DefectEntry` objects have a `bulk_entry` attribute, it is not needed to provide `bulk_entry` to `FormationEnergyDiagram`"
                     "The energy difference E[Defect SuperCell] - E[Bulk SuperCell] can be calculated directly from `DefectEntry.get_ediff`."
+                )
+        else:
+            if self.bulk_entry is None:
+                raise RuntimeError(
+                    "Not all of the `DefectEntry` objects have a `bulk_entry` attribute, you need to provide `bulk_entry` to `FormationEnergyDiagram`"
                 )
 
         bulk_entry = self.bulk_entry or self.defect_entries[0].bulk_entry
@@ -619,7 +624,10 @@ class MultiFormationEnergyDiagram(MSONable):
 
 
 def group_defects(defect_entries: list[DefectEntry]):
-    """Group defects by their representation."""
+    """Group defects by their representation.
+
+    TODO: Fix this with `defect_structure` grouping with `StructureMatcher`.
+    """
     sents = sorted(defect_entries, key=lambda x: x.defect.__repr__())
     for k, group in groupby(sents, key=lambda x: x.defect.__repr__()):
         yield k, list(group)

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -330,6 +330,8 @@ def cluster_nodes(
         lattice (Lattice): The lattice of the structure.
         tol (float): A distance tolerance. PBC is taken into account.
     """
+    if len(fcoords) <= 1:
+        return fcoords
     # Manually generate the distance matrix (which needs to take into
     # account PBC.
     dist_matrix = np.array(lattice.get_all_distances(fcoords, fcoords))

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -330,7 +330,7 @@ def cluster_nodes(
         lattice (Lattice): The lattice of the structure.
         tol (float): A distance tolerance. PBC is taken into account.
     """
-    if len(fcoords) <= 1:
+    if len(fcoords) <= 1:  # pragma: no cover
         return fcoords
     # Manually generate the distance matrix (which needs to take into
     # account PBC.

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import numpy as np
@@ -76,6 +77,36 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
         inc_inf_values=True,
     )
     assert len(fed.chempot_limits) == 5
+
+    # check that the constructor raises an error if `bulk_entry` is is provided for all defect entries
+    def_ents_w_bulk = copy.deepcopy(def_ent_list)
+    for dent in def_ents_w_bulk:
+        dent.bulk_entry = bulk_entry
+
+    fed = FormationEnergyDiagram(
+        defect_entries=def_ents_w_bulk,
+        vbm=vbm,
+        pd_entries=stable_entries_Mg_Ga_N,
+        inc_inf_values=True,
+    )
+    assert len(fed.chempot_limits) == 5
+
+    with pytest.raises(RuntimeError):
+        FormationEnergyDiagram(
+            bulk_entry=bulk_entry,
+            defect_entries=def_ents_w_bulk,
+            vbm=vbm,
+            pd_entries=stable_entries_Mg_Ga_N,
+            inc_inf_values=True,
+        )
+
+    with pytest.raises(RuntimeError):
+        FormationEnergyDiagram(
+            defect_entries=def_ent_list,
+            vbm=vbm,
+            pd_entries=stable_entries_Mg_Ga_N,
+            inc_inf_values=True,
+        )
 
     fed = FormationEnergyDiagram(
         bulk_entry=bulk_entry,

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -107,12 +107,12 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
     )
     pd = PhaseDiagram(stable_entries_Mg_Ga_N)
     fed = FormationEnergyDiagram.with_atomic_entries(
-        bulk_entry=bulk_entry,
         defect_entries=def_ent_list,
         atomic_entries=atomic_entries,
         vbm=vbm,
         inc_inf_values=False,
         phase_diagram=pd,
+        bulk_entry=bulk_entry,
     )
     assert len(fed.chempot_limits) == 3
 

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -39,7 +39,7 @@ def test_lower_envelope():
     ]
 
 
-def test_defect_entry(defect_entries_Mg_Ga):
+def test_defect_entry(defect_entries_Mg_Ga, data_Mg_Ga):
     defect_entries, plot_data = defect_entries_Mg_Ga
 
     def_entry = defect_entries[0]
@@ -58,6 +58,15 @@ def test_defect_entry(defect_entries_Mg_Ga):
     vr1 = plot_data[0][1]["pot_plot_data"]["Vr"]
     vr2 = defect_entries[0].corrections_metadata["freysoldt"][1]["pot_plot_data"]["Vr"]
     assert np.allclose(vr1, vr2)
+
+    bulk_vasprun = data_Mg_Ga["bulk_sc"]["vasprun"]
+    bulk_entry = bulk_vasprun.get_computed_entry(inc_structure=False)
+    def_entry = defect_entries[0]
+    assert def_entry.get_ediff() is None
+
+    def_entry.bulk_entry = bulk_entry
+    ediff = def_entry.sc_entry.energy - bulk_entry.energy
+    assert def_entry.get_ediff() == pytest.approx(ediff, abs=1e-4)
 
 
 def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga_N):

--- a/tests/test_thermo.py
+++ b/tests/test_thermo.py
@@ -77,7 +77,6 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
     defect_entries, plot_data = defect_entries_Mg_Ga
 
     def_ent_list = list(defect_entries.values())
-
     fed = FormationEnergyDiagram(
         bulk_entry=bulk_entry,
         defect_entries=def_ent_list,
@@ -100,15 +99,8 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
     )
     assert len(fed.chempot_limits) == 5
 
-    with pytest.raises(RuntimeError):
-        FormationEnergyDiagram(
-            bulk_entry=bulk_entry,
-            defect_entries=def_ents_w_bulk,
-            vbm=vbm,
-            pd_entries=stable_entries_Mg_Ga_N,
-            inc_inf_values=True,
-        )
-
+    # Raise error if bulk_entry is not provided when some
+    # of the defect entries are missing bulk_entry data
     with pytest.raises(RuntimeError):
         FormationEnergyDiagram(
             defect_entries=def_ent_list,
@@ -117,6 +109,8 @@ def test_formation_energy(data_Mg_Ga, defect_entries_Mg_Ga, stable_entries_Mg_Ga
             inc_inf_values=True,
         )
 
+    # if both bulk_entry and defect_entries.bulk_entry are provided (by accident)
+    # the code should still work.
     fed = FormationEnergyDiagram(
         bulk_entry=bulk_entry,
         defect_entries=def_ent_list,


### PR DESCRIPTION
# Charge Density Intersitial Finding

Current implementation error if there is only one local minimum since the distanace matrix cannot be constructed for clustering.
You can skip the clustering code if you don't have more than one local minimum.

# Defect Entry

Originally the `FormationEnergyDiagram` is defined by a set of `DefectEntry`s and one `bulk_entry`.
In a messier database the workflow might require you to stich together different defect/bulk pairs.
Aso since the energtrices of each charge state is solely determined by the a defect/bulk entry pair it makes more sense to keep them together for posterity.