### PR TITLE
Speed up oxidation state guessing using `max_sites` parameter

### DIFF
--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -82,7 +82,7 @@ class Defect(MSONable, metaclass=ABCMeta):
                 # check oxi_states assigned and not all zero
                 if all([specie.oxi_state == 0 for specie in self.structure.species]):
                     self.structure.add_oxidation_state_by_guess()
-            except: # pragma: no cover
+            except:  # pragma: no cover
                 self.structure.add_oxidation_state_by_guess()
             self.structure.add_oxidation_state_by_guess()
             self.oxi_state = self._guess_oxi_state()

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -75,13 +75,14 @@ class Defect(MSONable, metaclass=ABCMeta):
         )
         self.user_charges = user_charges if user_charges else []
         if oxi_state is None:
-            # TODO this step might take time so wrap it in a timer
+            # Try to use the reduced cell first since oxidation state assignment
+            # scales poorly with systems size.
             try:
                 self.structure.add_oxidation_state_by_guess(max_sites=-1)
                 # check oxi_states assigned and not all zero
                 if all([specie.oxi_state == 0 for specie in self.structure.species]):
                     self.structure.add_oxidation_state_by_guess()
-            except:
+            except: # pragma: no cover
                 self.structure.add_oxidation_state_by_guess()
             self.structure.add_oxidation_state_by_guess()
             self.oxi_state = self._guess_oxi_state()

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -76,6 +76,13 @@ class Defect(MSONable, metaclass=ABCMeta):
         self.user_charges = user_charges if user_charges else []
         if oxi_state is None:
             # TODO this step might take time so wrap it in a timer
+            try:
+                self.structure.add_oxidation_state_by_guess(max_sites=-1)
+                # check oxi_states assigned and not all zero
+                if all([specie.oxi_state == 0 for specie in self.structure.species]):
+                    self.structure.add_oxidation_state_by_guess()
+            except:
+                self.structure.add_oxidation_state_by_guess()
             self.structure.add_oxidation_state_by_guess()
             self.oxi_state = self._guess_oxi_state()
         else:


### PR DESCRIPTION
Hi @jmmshn!
This is a small suggested update to make initialised `Defect` objects more efficient, by reducing the time taken for the `add_oxidation_state_by_guess()` function. I noticed the poor quartic scaling of this function when trying to initialise a `Defect` with a very large bulk cell, e.g.:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/51478689/221437520-4751ad32-0147-4548-a4ae-976277ae131b.png">

Looking at the function code and docstrings, `max_sites` can be used to speed up the oxidation state guessing:
<img width="866" alt="image" src="https://user-images.githubusercontent.com/51478689/221437531-90d8ae2c-b701-4fba-ad38-d605a0c3cd69.png">

From testing, I found that for some edge cases (e.g. mixed-valence) this can cause the function to return an empty guess, so I added a check to avoid this.
