### PR TITLE
Remove duplicate oxi state guess (merge issue)

### DIFF
--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -84,7 +84,6 @@ class Defect(MSONable, metaclass=ABCMeta):
                     self.structure.add_oxidation_state_by_guess()
             except:  # pragma: no cover
                 self.structure.add_oxidation_state_by_guess()
-            self.structure.add_oxidation_state_by_guess()
             self.oxi_state = self._guess_oxi_state()
         else:
             self.oxi_state = oxi_state


### PR DESCRIPTION
Realised when testing that there was a merge issue with this that meant the full oxi-state guess function was run anyway, after doing the more efficient `max_sites=-1` one 😅 
Testing this all works as expected and much quicker initialisation when generating a range of defects at once!