### PR TITLE
Bug fix: add .values() for parsing through defect_locpot dictionary

### DIFF
--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -106,7 +106,12 @@ def get_freysoldt_correction(
     else:
         list_defect_plnr_avg_esp = defect_locpot
         list_axis_grid = [
-            *map(np.linspace, [0, 0, 0], lattice.abc, [len(i) for i in defect_locpot.values()])
+            *map(
+                np.linspace,
+                [0, 0, 0],
+                lattice.abc,
+                [len(i) for i in defect_locpot.values()],
+            )
         ]
 
     # TODO this can be done with regridding later

--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -106,7 +106,7 @@ def get_freysoldt_correction(
     else:
         list_defect_plnr_avg_esp = defect_locpot
         list_axis_grid = [
-            *map(np.linspace, [0, 0, 0], lattice.abc, [len(i) for i in defect_locpot])
+            *map(np.linspace, [0, 0, 0], lattice.abc, [len(i) for i in defect_locpot.values()])
         ]
 
     # TODO this can be done with regridding later


### PR DESCRIPTION
Was building defect entries today and found a bug when the user provides a dictionary for the defect_locpot (instead of `Locpot` object).  Btw -- it's not clear to a user that a dictionary can be provided, and in what format it should be provided in.

My fix: added `.values()` for iterating through the dictionary values. Is this what you intended to write @jmmshn? Or would it be more transparent if this line used `list_defect_plnr_avg_esp.values()`?