### PR TITLE
Major Fixes to Selective Dynamics and Oxidation

### DIFF
--- a/docs/source/content/freysoldt-correction.ipynb
+++ b/docs/source/content/freysoldt-correction.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -44,6 +45,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -83,6 +85,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -189,6 +192,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -363,10 +363,10 @@ class Substitution(Defect):
         """Returns the defect structure."""
         struct: Structure = self.structure.copy()
         struct.remove_sites([self.defect_site_index])
-        print(">>", self.site.species_string)
+        insert_el = get_element(self.site.specie)
         struct.insert(
             self.defect_site_index,
-            species=self.site.species_string,
+            species=insert_el,
             coords=np.mod(self.site.frac_coords, 1),
         )
         return struct

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -164,7 +164,7 @@ class Defect(MSONable, metaclass=ABCMeta):
         min_length: float = 10.0,
         force_diagonal: bool = False,
         relax_radius: float | str | None = None,
-        perturb: float = 0.0,
+        perturb: float | None = None,
     ) -> Structure:
         """Generate the supercell for a defect.
 
@@ -212,7 +212,7 @@ class Defect(MSONable, metaclass=ABCMeta):
             site_pos=sc_pos,
             relax_radius=relax_radius,
         )
-        if perturb > 0.0:
+        if perturb is not None:
             _perturb_dynamic_sites(sc_defect_struct, distance=perturb)
 
         return sc_defect_struct
@@ -585,7 +585,7 @@ class DefectComplex(Defect):
         min_length: float = 10.0,
         force_diagonal: bool = False,
         relax_radius: float | str | None = None,
-        perturb: float = 0.0,
+        perturb: float | None = None,
     ) -> Structure:
         """Generate the supercell for a defect.
 
@@ -633,7 +633,7 @@ class DefectComplex(Defect):
             relax_radius=relax_radius,
         )
 
-        if perturb > 0.0:
+        if perturb is not None:
             _perturb_dynamic_sites(sc_defect_struct, distance=perturb)
 
         return sc_defect_struct

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -209,7 +209,7 @@ class Defect(MSONable, metaclass=ABCMeta):
 
         _set_selective_dynamics(
             structure=sc_defect_struct,
-            site_pos=sc_pos,
+            site_pos=sc_site.coords,
             relax_radius=relax_radius,
         )
         if perturb is not None:
@@ -629,7 +629,7 @@ class DefectComplex(Defect):
 
         _set_selective_dynamics(
             structure=sc_defect_struct,
-            site_pos=sc_pos,
+            site_pos=sc_site.coords,
             relax_radius=relax_radius,
         )
 

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -737,7 +737,6 @@ def _set_selective_dynamics(structure, site_pos, relax_radius):
         relax_radius = min(get_plane_spacing(structure.lattice.matrix)) / 2.0
     if not isinstance(relax_radius, float):
         raise ValueError("relax_radius must be a float or 'auto' or None")
-
     structure.get_sites_in_sphere(site_pos, relax_radius)
     relax_sites = structure.get_sites_in_sphere(
         site_pos, relax_radius, include_index=True

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -362,16 +362,11 @@ class Substitution(Defect):
     def defect_structure(self) -> Structure:
         """Returns the defect structure."""
         struct: Structure = self.structure.copy()
-        rm_oxi = struct.sites[self.defect_site_index].specie.oxi_state
         struct.remove_sites([self.defect_site_index])
-        sub_states = self.site.specie.icsd_oxidation_states
-        if len(sub_states) == 0:
-            sub_states = self.site.specie.oxidation_states
-        sub_oxi = min(sub_states, key=lambda x: abs(x - rm_oxi))
-        sub_specie = Species(self.site.specie.symbol, sub_oxi)
+        print(">>", self.site.species_string)
         struct.insert(
             self.defect_site_index,
-            species=sub_specie,
+            species=self.site.species_string,
             coords=np.mod(self.site.frac_coords, 1),
         )
         return struct
@@ -412,9 +407,15 @@ class Substitution(Defect):
         Returns:
             float: The oxidation state of the defect.
         """
-        orig_site = self.defect_site
-        sub_site = self.defect_structure[self.defect_site_index]
-        return sub_site.specie.oxi_state - orig_site.specie.oxi_state
+        rm_oxi = self.structure[self.defect_site_index].specie.oxi_state
+        sub_states = self.site.specie.common_oxidation_states
+        if len(sub_states) == 0:
+            raise ValueError(
+                f"No common oxidation states found for {self.site.specie}."
+                "Please specify the oxidation state manually."
+            )
+        sub_oxi = sub_states[0]
+        return sub_oxi - rm_oxi
 
     def __repr__(self) -> str:
         """Representation of a substitutional defect."""

--- a/pymatgen/analysis/defects/finder.py
+++ b/pymatgen/analysis/defects/finder.py
@@ -48,18 +48,26 @@ class DefectSiteFinder(MSONable):
         self.angle_tolerance = angle_tolerance
 
     def get_defect_fpos(
-        self, defect_structure: Structure, base_structure: Structure
+        self,
+        defect_structure: Structure,
+        base_structure: Structure,
+        remove_oxi: bool = True,
     ) -> ArrayLike:
         """Get the position of a defect in the pristine structure.
 
         Args:
             defect_structure: Relaxed structure containing the defect
             base_structure: Structure for the pristine cell
+            remove_oxi: Whether to remove oxidation states from the structures
 
         Returns:
             ArrayLike: Position of the defect in the pristine structure
             (in fractional coordinates)
         """
+        if remove_oxi:
+            defect_structure.remove_oxidation_states()
+            base_structure.remove_oxidation_states()
+
         if self._is_impurity(defect_structure, base_structure):
             return self.get_impurity_position(defect_structure, base_structure)
         else:

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -146,7 +146,6 @@ class SubstitutionGenerator(DefectGenerator):
                     structure.lattice,
                     properties=site.properties,
                 )
-                print(sub_el, sub_site)
                 yield Substitution(structure, sub_site, **kwargs)
             elif isinstance(sub_el, list):
                 for el in sub_el:

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -146,6 +146,7 @@ class SubstitutionGenerator(DefectGenerator):
                     structure.lattice,
                     properties=site.properties,
                 )
+                print(sub_el, sub_site)
                 yield Substitution(structure, sub_site, **kwargs)
             elif isinstance(sub_el, list):
                 for el in sub_el:

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -404,8 +404,17 @@ def generate_all_native_defects(
     sub_generator: SubstitutionGenerator | None = None,
     vac_generator: VacancyGenerator | None = None,
     int_generator: ChargeInterstitialGenerator | None = None,
+    max_interstitials: int | None = None,
 ):
-    """Generate all native defects."""
+    """Generate all native defects.
+
+    Args:
+        host: The host structure or chgcar object.
+        sub_generator: The substitution generator, if None, a default generator is used.
+        vac_generator: The vacancy generator, if None, a default generator is used.
+        int_generator: The interstitial generator, if None, a default
+            ChargeInterstitialGenerator is used.
+    """
     if isinstance(host, Chgcar):
         struct = host.structure
         chgcar = host
@@ -427,7 +436,8 @@ def generate_all_native_defects(
     # generate interstitials if a chgcar is provided
     if chgcar is not None:
         int_generator = int_generator or ChargeInterstitialGenerator()
-        yield from int_generator.generate(chgcar, insert_species=species)
+        int_defects = [*int_generator.generate(chgcar, insert_species=species)]
+        yield from int_defects[:max_interstitials]
 
 
 def _element_str(sp_or_el: Species | Element) -> str:

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -1007,19 +1007,20 @@ def plot_formation_energy_diagrams(
     formation_energy_diagrams = list(filter(filterfunction, formation_energy_diagrams))
 
     band_gap = formation_energy_diagrams[0].band_gap
-    if not xlim and not band_gap:
+    if not xlim and band_gap is None:
         raise ValueError("Must specify xlim or set band_gap attribute")
 
     if axis is None:
         _, axis = plt.subplots()
-    axis.plot([0, 0], [0, 1], color=band_edge_color, linestyle="--", linewidth=1)
-    if not xlim and band_gap:
+    axis.axvline(band_gap, color=band_edge_color, linestyle="--", linewidth=1)
+    axis.axvline(0, color=band_edge_color, linestyle="--", linewidth=1)
+    if not xlim:
         xmin, xmax = np.subtract(-0.2, alignment), np.subtract(
             band_gap + 0.2, alignment
         )
     else:
         xmin, xmax = xlim
-    ymin, ymax = 0.0, 1.0
+    ymin, ymax = np.inf, -np.inf
     legends_txt = []
     artists = []
     fontwidth = 12
@@ -1051,9 +1052,12 @@ def plot_formation_energy_diagrams(
                 lowerlines, np.add(xmin, alignment), np.add(xmax, alignment)
             )
         )
+        trans_y = trans[:, 1]
+        ymin = min(ymin, min(trans_y))
+        ymax = max(ymax, max(trans_y))
         axis.plot(
             np.subtract(trans[:, 0], alignment),
-            trans[:, 1],
+            trans_y,
             color=colors[fid],
             ls=linestyle,
             lw=linewidth,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,8 +66,7 @@ def test_substitution(gan_struct):
     # test perturbation
     sc_locked = sub.get_supercell_structure(relax_radius=5.0, perturb=0.0)
     free_sites_ref2 = sc_locked.get_sites_in_sphere(cpos, 5.0, include_index=True)
-    free_sites_ref2 = [site.index for site in free_sites_ref]
-
+    free_sites_ref2 = [site.index for site in free_sites_ref2]
     assert set(free_sites_ref2) == set(free_sites_ref)
 
     # test for user defined charge

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,7 +67,7 @@ def test_substitution(gan_struct):
     sc_locked = sub.get_supercell_structure(relax_radius=5.0, perturb=0.0)
     free_sites_ref2 = sc_locked.get_sites_in_sphere(cpos, 5.0, include_index=True)
     free_sites_ref2 = [site.index for site in free_sites_ref]
-    
+
     assert set(free_sites_ref2) == set(free_sites_ref)
 
     # test for user defined charge

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,11 +56,13 @@ def test_substitution(gan_struct):
 
     finder = DefectSiteFinder()
     fpos = finder.get_defect_fpos(sc_locked, sub.structure)
-    free_sites_ref = sc_locked.get_sites_in_sphere(fpos, 5.0, include_index=True)
+    cpos = sc_locked.lattice.get_cartesian_coords(fpos)
+    free_sites_ref = sc_locked.get_sites_in_sphere(cpos, 5.0, include_index=True)
     free_sites_ref = [site.index for site in free_sites_ref]
     free_sites_union = set(free_sites_ref) | set(free_sites)
     free_sites_intersection = set(free_sites_ref) & set(free_sites)
-    assert len(free_sites_intersection) / len(free_sites_union) > 0.7
+    assert len(free_sites_intersection) / len(free_sites_union) == 1.0
+
     # Since there is some fuzziness in the finder algorithm, we only require 70% of the sites to be the same
 
     # test for user defined charge

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,7 +63,12 @@ def test_substitution(gan_struct):
     free_sites_intersection = set(free_sites_ref) & set(free_sites)
     assert len(free_sites_intersection) / len(free_sites_union) == 1.0
 
-    # Since there is some fuzziness in the finder algorithm, we only require 70% of the sites to be the same
+    # test perturbation
+    sc_locked = sub.get_supercell_structure(relax_radius=5.0, perturb=0.0)
+    free_sites_ref2 = sc_locked.get_sites_in_sphere(cpos, 5.0, include_index=True)
+    free_sites_ref2 = [site.index for site in free_sites_ref]
+    
+    assert set(free_sites_ref2) == set(free_sites_ref)
 
     # test for user defined charge
     dd = sub.as_dict()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,5 @@
 import numpy as np
 from pymatgen.core.periodic_table import Element, Specie
-from pymatgen.io.vasp import Poscar
 
 from pymatgen.analysis.defects.core import (
     Adsorbate,
@@ -10,6 +9,7 @@ from pymatgen.analysis.defects.core import (
     Substitution,
     Vacancy,
 )
+from pymatgen.analysis.defects.finder import DefectSiteFinder
 
 
 def test_vacancy(gan_struct):
@@ -47,10 +47,21 @@ def test_substitution(gan_struct):
     assert sub.element_changes == {Element("N"): -1, Element("O"): 1}
 
     # test supercell with locking
-    sc_locked = sub.get_supercell_structure(relax_radius=1.0)
-    poscar_locked = Poscar(sc_locked)
-    poscar_string = poscar_locked.get_string()
-    assert len(poscar_string.split("\n")) == 138
+    sc_locked = sub.get_supercell_structure(relax_radius=5.0)
+    free_sites = [
+        i
+        for i, site in enumerate(sc_locked)
+        if site.properties["selective_dynamics"][0]
+    ]
+
+    finder = DefectSiteFinder()
+    fpos = finder.get_defect_fpos(sc_locked, sub.structure)
+    free_sites_ref = sc_locked.get_sites_in_sphere(fpos, 5.0, include_index=True)
+    free_sites_ref = [site.index for site in free_sites_ref]
+    free_sites_union = set(free_sites_ref) | set(free_sites)
+    free_sites_intersection = set(free_sites_ref) & set(free_sites)
+    assert len(free_sites_intersection) / len(free_sites_union) > 0.7
+    # Since there is some fuzziness in the finder algorithm, we only require 70% of the sites to be the same
 
     # test for user defined charge
     dd = sub.as_dict()


### PR DESCRIPTION
- Fixed major but in the construction of the selective dynamics sphere and added tests.  The older verions had a typo in the sphere center position.
- Allow the selectively dynamic atoms to be perturbed randomly
- Split the logic for oxidation state and defect structure definition in Substitutions
- Changed the oxidation state to use the first common oxidation state for the Substituted atom 

```python
        rm_oxi = self.structure[self.defect_site_index].specie.oxi_state
        sub_states = self.site.specie.common_oxidation_states
        sub_oxi = sub_states[0]
        return sub_oxi - rm_oxi
```