### PR TITLE
Generator fixes

### DIFF
--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -283,7 +283,7 @@ class VoronoiInterstitialGenerator(InterstitialGenerator):
         self.stol = stol
         self.angle_tol = angle_tol
         self.top_kwargs = kwargs
-        super().__init__()
+        super().__init__(min_dist=min_dist)
 
     def generate(self, structure: Structure, insert_species: set[str] | list[str], **kwargs) -> Generator[Interstitial, None, None]:  # type: ignore[override]
         """Generate interstitials.

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -316,7 +316,16 @@ class VoronoiInterstitialGenerator(InterstitialGenerator):
         """
         framework = list(structure.symbol_set)
         top = TopographyAnalyzer(
-            structure, framework, [], check_volume=False, **self.top_kwargs
+            structure,
+            framework,
+            [],
+            check_volume=False,
+            clustering_tol=self.clustering_tol,
+            min_dist=self.min_dist,
+            ltol=self.ltol,
+            stol=self.stol,
+            angle_tol=self.angle_tol,
+            **self.top_kwargs,
         )
         insert_sites = dict()
         multiplicity: dict[int, int] = dict()

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -207,7 +207,7 @@ class InterstitialGenerator(DefectGenerator):
         self,
         structure: Structure,
         insertions: dict[str, list[list[float]]],
-        multiplicies: dict[str, list[int]] | None = None,
+        multiplicities: dict[str, list[int]] | None = None,
         **kwargs,
     ) -> Generator[Interstitial, None, None]:
         """Generate interstitials.
@@ -215,20 +215,20 @@ class InterstitialGenerator(DefectGenerator):
         Args:
             structure: The bulk structure the interstitials are generated from.
             insertions: The insertions to be made given as a dictionary {"Mg": [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]]}.
-            multiplicies: The multiplicities of the insertions to be made given as a dictionary {"Mg": [1, 2]}.
+            multiplicities: The multiplicities of the insertions to be made given as a dictionary {"Mg": [1, 2]}.
             **kwargs: Additional keyword arguments for the ``Interstitial`` constructor.
 
         Returns:
             Generator[Interstitial, None, None]: Generator that yields a list of ``Interstitial`` objects
         """
-        if multiplicies is None:
-            multiplicies = {
+        if multiplicities is None:
+            multiplicities = {
                 el_str: [1] * len(coords) for el_str, coords in insertions.items()
             }
 
         for el_str, coords in insertions.items():
             for i, coord in self._filter_colliding(coords, structure=structure):
-                mul = multiplicies[el_str][i]
+                mul = multiplicities[el_str][i]
                 isite = PeriodicSite(
                     species=Species(el_str), coords=coord, lattice=structure.lattice
                 )
@@ -300,7 +300,7 @@ class VoronoiInterstitialGenerator(InterstitialGenerator):
             yield from super().generate(
                 structure,
                 insertions={species: cand_sites},
-                multiplicies={species: multiplicity},
+                multiplicities={species: multiplicity},
                 **kwargs,
             )
 
@@ -390,7 +390,7 @@ class ChargeInterstitialGenerator(InterstitialGenerator):
             yield from super().generate(
                 chgcar.structure,
                 insertions={species: cand_sites},
-                multiplicies={species: multiplicity},
+                multiplicities={species: multiplicity},
                 **kwargs,
             )
 

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -227,9 +227,7 @@ class InterstitialGenerator(DefectGenerator):
             }
 
         for el_str, coords in insertions.items():
-            for i, coord in enumerate(
-                self._filter_colliding(coords, structure=structure)
-            ):
+            for i, coord in self._filter_colliding(coords, structure=structure):
                 mul = multiplicies[el_str][i]
                 isite = PeriodicSite(
                     species=Species(el_str), coords=coord, lattice=structure.lattice
@@ -250,10 +248,10 @@ class InterstitialGenerator(DefectGenerator):
             fcoords=list(unique_fcoords), structure=structure, min_dist=self.min_dist
         )
         cleaned_fcoords = set(tuple(f) for f in cleaned_fcoords)
-        for fc in fcoords:
+        for i, fc in enumerate(fcoords):
             if tuple(fc) not in cleaned_fcoords:
                 continue
-            yield fc
+            yield i, fc
 
 
 class VoronoiInterstitialGenerator(InterstitialGenerator):

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -236,7 +236,7 @@ class InterstitialGenerator(DefectGenerator):
 
     def _filter_colliding(
         self, fcoords: list[list[float]], structure: Structure
-    ) -> Generator[list[float], None, None]:
+    ) -> Generator[tuple[int, list[float]], None, None]:
         """Check the sites for collisions.
 
         Args:


### PR DESCRIPTION
These are just some small fixes for the `generators.py` module I noticed from playing around with some of the code recently. 
- Pass `VoronoiInterstitialGenerator` parameters through to `TopographyAnalyzer`; previously setting `stol`, `clustering_tol` etc would not affect the interstitial generation as these tags were being ignored.
- Pass `min_dist` from `VoronoiInterstitialGenerator` through to `super()` (i.e. `InterstitialGenerator`) initialisation, so that it's then used in the later `super().generate()` call in `VoronoiInterstitialGenerator`'s `generate()` method (tested and this now works as expected).
- Refactor `_filter_colliding` to return coords _and_ index, for correct multiplicities; previously when iterating over the subset of coordinates returned by `_filter_colliding` (with `enumerate()` to get the indices), the indices would differ from those of `multiplicities` (which matched the input coordinate list to `_filter_colliding`) because we are filtering out a subset of the input coordinates here, so then the multiplicities (selected with `multiplicitiespel_str][i]`) would become out of sync as the index `i` was mis-matched. (Took me a while to figure out where this was happening in the generation step 😅)