### PR TITLE
Bugfix for corrections handling

### DIFF
--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -155,7 +155,7 @@ class DefectEntry(MSONable):
     @property
     def corrected_energy(self) -> float:
         """The energy of the defect entry with all corrections applied."""
-        return self.sc_entry.energy + self.corrections["freysoldt"]
+        return self.sc_entry.energy + sum(self.corrections.values())
 
     def get_ediff(self) -> float | None:
         """Get the energy difference between the defect and the bulk (including finite-size correction)."""


### PR DESCRIPTION
Just a quick bugfix for getting the `DefectEntry.corrected_energy` (and thus `get_ediff()`).
It says in the docstring it includes all corrections to the energy, but then just takes specifically the `freysoldt_correction` one (which will also break if there is no `freysoldt_correction` entry in the corrections dictionary).

This fixes it by taking the sum of the values