### PR TITLE
Patch locpot

### DIFF
--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -286,8 +286,8 @@ class HarmonicDefect(MSONable):
                 )
             charge_state = vaspruns[0].final_structure.charge
 
-        if any(v.final_structure.charge != charge_state for v in vaspruns):
-            raise ValueError("All vaspruns must have the same charge state.")
+            if any(v.final_structure.charge != charge_state for v in vaspruns):
+                raise ValueError("All vaspruns must have the same charge state.")
 
         return cls.from_vaspruns(
             vaspruns=vaspruns,

--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -286,8 +286,8 @@ class HarmonicDefect(MSONable):
                 )
             charge_state = vaspruns[0].final_structure.charge
 
-            if any(v.final_structure.charge != charge_state for v in vaspruns):
-                raise ValueError("All vaspruns must have the same charge state.")
+        if any(v.final_structure.charge != charge_state for v in vaspruns):
+            raise ValueError("All vaspruns must have the same charge state.")
 
         return cls.from_vaspruns(
             vaspruns=vaspruns,

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -163,7 +163,12 @@ class Defect(MSONable, metaclass=ABCMeta):
         if isinstance(self.oxi_state, int) or self.oxi_state.is_integer():
             oxi_state = int(self.oxi_state)
         else:  # pragma: no cover
-            raise ValueError("Oxidation state must be an integer")
+            sign = -1 if self.oxi_state < 0 else 1
+            oxi_state = sign * int(np.ceil(abs(self.oxi_state)))
+            _logger.warn(
+                "Non-integer oxidation state detected."
+                f"Rounding to integer with larger absolute value: {self.oxi_state} -> {oxi_state}"
+            )
 
         if oxi_state >= 0:
             charges = [*range(-padding, oxi_state + padding + 1)]

--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -18,7 +18,7 @@ from pymatgen.analysis.defects.utils import (
     generate_reciprocal_vectors_squared,
     hart_to_ev,
 )
-from pymatgen.io.vasp.outputs import Locpot
+from pymatgen.io.vasp.outputs import Locpot, VolumetricData
 from scipy import stats
 
 if TYPE_CHECKING:
@@ -104,7 +104,7 @@ def get_freysoldt_correction(
 
     q_model = QModel() if q_model is None else q_model
 
-    if isinstance(defect_locpot, Locpot):
+    if isinstance(defect_locpot, VolumetricData):
         list_axis_grid = [*map(defect_locpot.get_axis_grid, [0, 1, 2])]
         list_defect_plnr_avg_esp = [
             *map(defect_locpot.get_average_along_axis, [0, 1, 2])
@@ -130,7 +130,7 @@ def get_freysoldt_correction(
         raise ValueError("defect_locpot must be of type Locpot or dict")
 
     # TODO this can be done with regridding later
-    if isinstance(bulk_locpot, Locpot):
+    if isinstance(bulk_locpot, VolumetricData):
         list_bulk_plnr_avg_esp = [*map(bulk_locpot.get_average_along_axis, [0, 1, 2])]
     elif isinstance(bulk_locpot, dict):
         bulk_locpot_ = {int(k): v for k, v in bulk_locpot.items()}

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -22,7 +22,7 @@ from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatc
 from pymatgen.core import Composition, Element
 from pymatgen.electronic_structure.dos import FermiDos
 from pymatgen.entries.computed_entries import ComputedEntry
-from pymatgen.io.vasp import Locpot, Vasprun
+from pymatgen.io.vasp import Chgcar, Locpot, Vasprun, VolumetricData
 from pyrho.charge_density import get_volumetric_like_sc
 from scipy.constants import value as _cd
 from scipy.optimize import bisect
@@ -147,12 +147,12 @@ class DefectEntry(MSONable):
         else:  # pragma: no cover
             defect_fpos = self.sc_defect_frac_coords
 
-        if isinstance(defect_locpot, Locpot):
+        if isinstance(defect_locpot, VolumetricData):
             defect_gn = defect_locpot.dim
         elif isinstance(defect_locpot, dict):
             defect_gn = tuple(map(len, (defect_locpot for k in ["0", "1", "2"])))
 
-        if isinstance(bulk_locpot, Locpot):
+        if isinstance(bulk_locpot, VolumetricData):
             bulk_sc_locpot = get_sc_locpot(
                 uc_locpot=bulk_locpot,
                 defect_struct=defect_struct,
@@ -165,7 +165,7 @@ class DefectEntry(MSONable):
             q=self.charge_state,
             dielectric=dielectric,
             defect_locpot=defect_locpot,
-            bulk_locpot=bulk_sc_locpot,
+            bulk_locpot=bulk_locpot,
             defect_frac_coords=defect_fpos,
             lattice=defect_struct.lattice,
             **kwargs,


### PR DESCRIPTION
## Minor Fixes


1.  Allow non-integer oxidation state for `Defect.get_charge_states()`
2. Allow any type `VolumetricData` to be used for the `locpot` feilds.  Sometimes Locpots are serialized as Chgcars by atomate2 but they are functionally the same.
3. Make sure that the ASE supercell generator respects `min_length`