### PR TITLE
Fix compatibility with new `pymatgen`

### DIFF
--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -18,7 +18,7 @@ import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
 from numpy.linalg import norm
-from pymatgen.analysis.local_env import cn_opt_params
+from pymatgen.analysis.local_env import CN_OPT_PARAMS
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
 from pymatgen.core.periodic_table import Element, get_el_sp
@@ -60,7 +60,7 @@ invang_to_ev = 3.80986
 kumagai_to_V = 1.809512739e2  # = Electron charge * 1e10 / VacuumPermittivity Constant
 
 motif_cn_op = {}
-for cn, di in cn_opt_params.items():
+for cn, di in CN_OPT_PARAMS.items():
     for motif, li in di.items():
         motif_cn_op[motif] = {"cn": int(cn), "optype": li[0]}
         motif_cn_op[motif]["params"] = deepcopy(li[1]) if len(li) > 1 else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "pymatgen>=2024.5.1",
+  "pymatgen>=2024.10.22",
   "scikit-image>=0.19.3",
   "numpy<2",
   "mp-pyrho>=0.4.4",
@@ -44,7 +44,7 @@ strict = [
   "pydefect==0.9.4",
 ]
 
-tests = ["pytest==8.2.1", "pytest-cov==5.0.0", "nbmake==1.5.3"]
+tests = ["pytest>=8.2.1", "pytest-cov>=5.0.0", "nbmake>=1.5.3"]
 
 [tool.setuptools.dynamic]
 readme = { file = ["README.md"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,6 @@ docs = [
   "jupyter-book>=0.13.1",
 ]
 optional = ["pydefect", "dscribe>=2.0.0", "numba"]
-
-strict = [
-  "pymatgen==2024.5.1",
-  "dscribe==2.1.1",
-  "mp-pyrho==0.4.4",
-  "pydefect==0.9.4",
-]
-
 tests = ["pytest>=8.2.1", "pytest-cov>=5.0.0", "nbmake>=1.5.3"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Hi!
The latest `pymatgen` release breaks for `pymatgen-analysis-defects` (and all tests in `doped`/`ShakeNBreak` as a result) due to a name change in `pymatgen.analysis.local_env`. This fixes it.


```
Traceback:
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/_pytest/python.py:493: in importtestmodule
    mod = import_path(
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/_pytest/pathlib.py:582: in import_path
    importlib.import_module(module_name)
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
tests/test_analysis.py:20: in <module>
    from test_thermodynamics import custom_mpl_image_compare
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:184: in exec_module
    exec(co, module.__dict__)
tests/test_thermodynamics.py:24: in <module>
    from doped.generation import _sort_defect_entries
doped/generation.py:20: in <module>
    from pymatgen.analysis.defects import core, thermo
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/pymatgen/analysis/defects/core.py:19: in <module>
    from .utils import get_plane_spacing
/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/pymatgen/analysis/defects/utils.py:21: in <module>
    from pymatgen.analysis.local_env import cn_opt_params
E   ImportError: cannot import name 'cn_opt_params' from 'pymatgen.analysis.local_env' (/opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/site-packages/pymatgen/analysis/local_env.py)
```