### PR TITLE
Bugfix for Interstitial Oxidation States

### DIFF
--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -708,7 +708,7 @@ class Interstitial(Defect):
         struct: Structure = self.structure.copy()
         # use the highest value oxidation state among the two most popular ones
         # found in the ICSD
-        inter_states = self.site.specie.icsd_oxidation_states[:2]
+        inter_states = self.site.specie.icsd_oxidation_states
         if len(inter_states) == 0:
             _logger.warning(
                 "No oxidation states found for %s. "

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -706,9 +706,9 @@ class Interstitial(Defect):
     def defect_structure(self) -> Structure:
         """Returns the defect structure."""
         struct: Structure = self.structure.copy()
-        # use the highest value oxidation state among the two most popular ones
+        # use the highest value oxidation state among the most popular ones
         # found in the ICSD
-        inter_states = self.site.specie.icsd_oxidation_states
+        inter_states = self.site.specie.common_oxidation_states
         if len(inter_states) == 0:
             _logger.warning(
                 "No oxidation states found for %s. "

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -119,8 +119,8 @@ def test_interstitial(gan_struct) -> None:
     inter_fpos = [0, 0, 0.75]
     n_site = PeriodicSite(Specie("N"), inter_fpos, s.lattice)
     inter = Interstitial(s, n_site)
-    assert inter.oxi_state == 3
-    assert inter.get_charge_states() == [-1, 0, 1, 2, 3, 4]
+    assert inter.oxi_state == 5
+    assert inter.get_charge_states() == [-1, 0, 1, 2, 3, 4, 5, 6]
     assert np.allclose(inter.defect_structure[0].frac_coords, inter_fpos)
     sc = inter.get_supercell_structure()
     assert sc.formula == "Ga64 N65"


### PR DESCRIPTION
The current code for getting `Interstitial` oxidation states takes the first two possibilities in `Element.icsd_oxidation_states`. However these are not ordered by probability, and so for e.g. Sn this ends up giving +3 for the interstitial oxidation state (rather than +4 or +2 which are more reasonable).

<img width="432" alt="image" src="https://github.com/user-attachments/assets/9365a8db-92e6-4d8c-a6c9-c5c5a9685d22">

This fix updates to preferentially use `Element.common_oxidation_states` (as used in `Substitution` oxi state guessing).