### PR TITLE
Fix antisite generation in mixed-valence systems

### DIFF
--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -103,10 +103,10 @@ class VacancyGenerator(DefectGenerator):
         Returns:
             Generator[Vacancy, None, None]: Generator that yields a list of ``Vacancy`` objects.
         """
-        all_species = [*map(_element_str, structure.composition.elements)]
-        rm_species = all_species if rm_species is None else [*map(str, rm_species)]
+        all_species = {*map(_element_str, structure.composition.elements)}
+        rm_species = all_species if rm_species is None else {*map(str, rm_species)}
 
-        if not set(rm_species).issubset(all_species):
+        if not rm_species.issubset(all_species):
             msg = f"rm_species({rm_species}) must be a subset of the structure's species ({all_species})."
             raise ValueError(
                 msg,
@@ -235,7 +235,7 @@ class AntiSiteGenerator(DefectGenerator):
             structure: The bulk structure the anti-site defects are generated from.
             **kwargs: Additional keyword arguments for the ``Substitution.generate`` function.
         """
-        all_species = [*map(_element_str, structure.composition.elements)]
+        all_species = {*map(_element_str, structure.composition.elements)}
         subs = collections.defaultdict(list)
         for u, v in combinations(all_species, 2):
             subs[u].append(v)

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -90,7 +90,7 @@ class VacancyGenerator(DefectGenerator):
     def generate(
         self,
         structure: Structure,
-        rm_species: list[str | Species] | None = None,
+        rm_species: set[str | Species] | list[str | Species] | None = None,
         **kwargs,
     ) -> Generator[Vacancy, None, None]:
         """Generate a vacancy defects.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
+import numpy as np
 
 import pytest
 from monty.serialization import loadfn
@@ -21,6 +22,14 @@ def test_dir():
 @pytest.fixture(scope="session")
 def gan_struct(test_dir):
     return Structure.from_file(test_dir / "GaN.vasp")
+
+@pytest.fixture(scope="session")
+def mixed_valence_struct(test_dir):
+    return Structure(
+        lattice=np.array([[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]]),
+        species=["Cu+", "Cu+", "Cu2+", "O2-"],
+        coords=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [0.5, 0.5, 0.0], [0.5, 0.0, 0.5]],
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def test_dir():
 def gan_struct(test_dir):
     return Structure.from_file(test_dir / "GaN.vasp")
 
+
 @pytest.fixture(scope="session")
 def mixed_valence_struct(test_dir):
     return Structure(

--- a/tests/test_ccd.py
+++ b/tests/test_ccd.py
@@ -24,7 +24,7 @@ def hd0(v_ga):
     )
     assert hd0.spin_index == 1
     assert pytest.approx(hd0.distortions[1]) == 0.0
-    assert pytest.approx(hd0.omega_eV) == 0.03268045792725
+    assert pytest.approx(hd0.omega_eV, rel=1e-4) == 0.03268045792725
     assert hd0.defect_band == [(138, 0, 1), (138, 1, 1)]
     assert hd0._get_ediff(output_order="bks").shape == (216, 2, 2)
     assert hd0._get_ediff(output_order="skb").shape == (2, 2, 216)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -54,6 +54,12 @@ def test_antisite_generator(gan_struct) -> None:
     def_names = [defect.name for defect in anti_gen]
     assert sorted(def_names) == ["Ga_N", "N_Ga"]
 
+def test_mixed_valence_antisite_generator(mixed_valence_struct) -> None:
+    anti_gen = AntiSiteGenerator().get_defects(mixed_valence_struct)
+    def_names = [defect.name for defect in anti_gen]
+    assert "Cu_Cu" not in def_names
+    assert set(def_names) == {"Cu_O", "O_Cu"}
+
 
 def test_interstitial_generator(gan_struct) -> None:
     gen = InterstitialGenerator().get_defects(

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -54,6 +54,7 @@ def test_antisite_generator(gan_struct) -> None:
     def_names = [defect.name for defect in anti_gen]
     assert sorted(def_names) == ["Ga_N", "N_Ga"]
 
+
 def test_mixed_valence_antisite_generator(mixed_valence_struct) -> None:
     anti_gen = AntiSiteGenerator().get_defects(mixed_valence_struct)
     def_names = [defect.name for defect in anti_gen]


### PR DESCRIPTION
Context: https://github.com/SMTG-Bham/doped/issues/96

Flagged by @alexsquires, for mixed-valence systems `AntisiteGenerator` gives `X_X` substitutions. Using sets instead of lists for determining the elements in the structure fixes this issue (see discussion in linked issue). Added a test for this behaviour too, and confirmed it fixes the downstream issue noted in `doped`