### PR TITLE
Fix for interstitial elements without known oxidation states

### DIFF
--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -716,7 +716,7 @@ class Interstitial(Defect):
                 self.site.specie.symbol,
             )
             inter_states = self.site.specie.oxidation_states
-        inter_oxi = max(inter_states, key=abs)
+        inter_oxi = max(inter_states + (0,), key=abs)
         int_specie = Species(self.site.specie.symbol, inter_oxi)
         struct.insert(
             0,

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -716,7 +716,7 @@ class Interstitial(Defect):
                 self.site.specie.symbol,
             )
             inter_states = self.site.specie.oxidation_states
-        inter_oxi = max(inter_states + (0,), key=abs)
+        inter_oxi = max((*inter_states, 0), key=abs)
         int_specie = Species(self.site.specie.symbol, inter_oxi)
         struct.insert(
             0,

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -711,7 +711,7 @@ class Interstitial(Defect):
         inter_states = self.site.specie.common_oxidation_states
         if len(inter_states) == 0:
             _logger.warning(
-                "No oxidation states found for %s. "
+                "No oxidation states found for %s "
                 "in ICSD using `oxidation_states` without frequency ranking.",
                 self.site.specie.symbol,
             )


### PR DESCRIPTION
Interstitial generation fails for elements without known/tabulated oxidation states (e.g. Xe):
<img width="808" alt="image" src="https://github.com/user-attachments/assets/bc315b7a-46a5-4b25-8c3e-6c7b0dc31be5">

This adds a small fix for this (just reverts to 0 if no oxi states found). My other interstitial fix last week makes this occurrence less likely to happen, but can still happen in some rare cases as shown for Xe, so this is a failsafe.

Full traceback:
```
ValueError                                Traceback (most recent call last)
Cell In[3], line 4
      2 from pymatgen.core.structure import Structure, PeriodicSite
      3 cdte = Structure.from_file("../examples/CdTe/relaxed_primitive_POSCAR")
----> 4 int = Interstitial(cdte, PeriodicSite("Xe", cdte.lattice, [0,0,0]))

File ~/Packages/pymatgen-analysis-defects/pymatgen/analysis/defects/core.py:682, in Interstitial.__init__(self, structure, site, multiplicity, oxi_state, equivalent_sites, symprec, angle_tolerance, user_charges)
    656 def __init__(
    657     self,
    658     structure: Structure,
   (...)
    665     user_charges: list[int] | None = None,
    666 ) -> None:
    667     """Initialize an interstitial defect object.
    668 
    669     The interstitial defect effectively inserts the `site` object into the structure.
   (...)
    680         user_charges: User specified charge states. If specified,
    681     """
--> 682     super().__init__(
    683         structure=structure,
    684         site=site,
    685         multiplicity=multiplicity,
    686         oxi_state=oxi_state,
    687         equivalent_sites=equivalent_sites,
    688         symprec=symprec,
    689         angle_tolerance=angle_tolerance,
    690         user_charges=user_charges,
    691     )

File ~/Packages/pymatgen-analysis-defects/pymatgen/analysis/defects/core.py:100, in Defect.__init__(self, structure, site, multiplicity, oxi_state, equivalent_sites, symprec, angle_tolerance, user_charges)
     98     except Exception:  # noqa: BLE001 # pragma: no cover
     99         self.structure.add_oxidation_state_by_guess()
--> 100     self.oxi_state = self._guess_oxi_state()
    101 else:
    102     self.oxi_state = oxi_state

File ~/Packages/pymatgen-analysis-defects/pymatgen/analysis/defects/core.py:754, in Interstitial._guess_oxi_state(self)
    744 def _guess_oxi_state(self) -> float:
    745     """Best guess for the oxidation state of the defect.
    746 
    747     For interstitials, just use the oxidation state of the site.
   (...)
    752         float: The oxidation state of the defect.
    753     """
--> 754     sub_site = self.defect_structure[self.defect_site_index]
    755     return sub_site.specie.oxi_state

File ~/Packages/pymatgen-analysis-defects/pymatgen/analysis/defects/core.py:719, in Interstitial.defect_structure(self)
    713     _logger.warning(
    714         "No oxidation states found for %s. "
    715         "in ICSD using `oxidation_states` without frequency ranking.",
    716         self.site.specie.symbol,
    717     )
    718     inter_states = self.site.specie.oxidation_states
--> 719 inter_oxi = max(inter_states, key=abs)
    720 int_specie = Species(self.site.specie.symbol, inter_oxi)
    721 struct.insert(
    722     0,
    723     species=int_specie,
    724     coords=np.mod(self.site.frac_coords, 1),
    725 )

ValueError: max() arg is an empty sequence
```
