### PR TITLE
chore: use NumPy v2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
   "pymatgen>=2024.10.22",
   "scikit-image>=0.19.3",
-  "numpy<2",
+  "numpy>=2.0.0,<3.0.0",
   "mp-pyrho>=0.4.4",
 ]
 description = "Pymatgen extension for defects analysis"


### PR DESCRIPTION
## Summary

I just tried to run tests for modules and notebooks on NumPy (+ Python 3.13). I confirmed it works without any issue, so I'd like to know a concern for NumPy v2 (I'd like to work on!).

🔗. https://github.com/materialsproject/pymatgen-analysis-defects/issues/216

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
  - https://github.com/himkt/pymatgen-analysis-defects/actions/runs/18054940932/job/51383431147?pr=1#step:5:31
- [ ] ~Tests added for new features/fixes.~
- [ ] ~If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))~

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```

->

```sh
> pre-commit run --all-files
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
codespell................................................................Passed
nbstripout...............................................................Passed
```