### PR TITLE
Refactor to only require `pymatgen-core`, and fix docs building

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,10 +88,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[docs]
       - name: Build
-        if: github.ref == 'refs/heads/develop'
-        # This line below is wrong and needs to be updated
         run: jupyter-book build --path-output docs docs/source
-        # Develop branch only
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}
@@ -59,7 +59,7 @@ jobs:
         run: pytest --nbmake ./docs/source/content
 
       - uses: codecov/codecov-action@v4
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.13'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/pymatgen/analysis/defects/ccd.py
+++ b/pymatgen/analysis/defects/ccd.py
@@ -184,7 +184,7 @@ class HarmonicDefect(MSONable):
             energy_struct[-1],
             lambda x, y: get_dQ(x[1], y[1]),
         )
-        energies, structures = list(zip(*sorted_list))
+        energies, structures = list(zip(*sorted_list, strict=False))
 
         if not np.allclose(unsorted_e, energies, atol=1e-99):  # pragma: no cover
             msg = "The vaspruns should already be in order."
@@ -347,7 +347,8 @@ class HarmonicDefect(MSONable):
                 msg,
             )
         self.wswqs = [
-            {"Q": d, "wswq": WSWQ.from_file(f)} for d, f in zip(distortions, wswq_files)
+            {"Q": d, "wswq": WSWQ.from_file(f)}
+            for d, f in zip(distortions, wswq_files, strict=False)
         ]
 
     def get_elph_me(self, defect_state: tuple) -> npt.ArrayLike:
@@ -574,7 +575,7 @@ def get_dQ(ground: Structure, excited: Structure) -> float:
         np.sum(
             [
                 x[0].distance(x[1]) ** 2 * x[0].specie.atomic_mass
-                for x in zip(ground, excited)
+                for x in zip(ground, excited, strict=False)
             ],
         ),
     )
@@ -631,7 +632,12 @@ def _get_wswq_slope(distortions: list[float], wswqs: list[WSWQ]) -> npt.NDArray:
             Since there is always ambiguity in the phase, we require that the output
             is always positive.
     """
-    yy = np.stack([np.abs(ww.data) * np.sign(qq) for qq, ww in zip(distortions, wswqs)])
+    yy = np.stack(
+        [
+            np.abs(ww.data) * np.sign(qq)
+            for qq, ww in zip(distortions, wswqs, strict=False)
+        ]
+    )
     _, *oldshape = yy.shape
     return np.polyfit(distortions, yy.reshape(yy.shape[0], -1), deg=1)[0].reshape(
         *oldshape,

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -11,18 +11,19 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.json import MSONable
 from pymatgen.analysis.defects.supercells import get_sc_fromstruct
-from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Element, PeriodicSite, Species
 from pymatgen.core.periodic_table import DummySpecies
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from .utils import get_plane_spacing
 
 if TYPE_CHECKING:
+    from typing import Self
+
     from numpy.typing import ArrayLike
     from pymatgen.core import Structure
     from pymatgen.symmetry.structure import SymmetrizedStructure
-    from typing_extensions import Self
 
 # TODO Possible redesign idea: ``DefectSite`` class defined with a defect object.
 # This makes some of the accounting logic a bit harder since we will probably

--- a/pymatgen/analysis/defects/core.py
+++ b/pymatgen/analysis/defects/core.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from monty.json import MSONable
 from pymatgen.analysis.defects.supercells import get_sc_fromstruct
-from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Element, PeriodicSite, Species
 from pymatgen.core.periodic_table import DummySpecies
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer

--- a/pymatgen/analysis/defects/corrections/freysoldt.py
+++ b/pymatgen/analysis/defects/corrections/freysoldt.py
@@ -162,6 +162,7 @@ def get_freysoldt_correction(
         list_bulk_plnr_avg_esp,
         list_defect_plnr_avg_esp,
         [0, 1, 2],
+        strict=False,
     ):
         alignment_corr, md = perform_pot_corr(
             axis_grid=x,

--- a/pymatgen/analysis/defects/finder.py
+++ b/pymatgen/analysis/defects/finder.py
@@ -124,7 +124,10 @@ class DefectSiteFinder(MSONable):
             (in fractional coordinates)
         """
         distored_sites, distortions = list(
-            zip(*self.get_most_distorted_sites(defect_structure, base_structure)),
+            zip(
+                *self.get_most_distorted_sites(defect_structure, base_structure),
+                strict=False,
+            ),
         )
         positions = [defect_structure[isite].frac_coords for isite in distored_sites]
         return get_weighted_average_position(
@@ -370,7 +373,7 @@ def get_weighted_average_position(
         raise ValueError(msg)
 
     # TODO: can be replaced with the zip(..., strict=True) syntax in Python 3.10
-    pos_weights = list(zip(frac_positions, weights))
+    pos_weights = list(zip(frac_positions, weights, strict=False))
     pos_weights.sort(key=lambda x: x[1], reverse=True)
 
     # initial guess at the center with zero weight

--- a/pymatgen/analysis/defects/generators.py
+++ b/pymatgen/analysis/defects/generators.py
@@ -388,7 +388,9 @@ class VoronoiInterstitialGenerator(InterstitialGenerator):
             raise ValueError(msg)
         cand_sites_mul_and_equiv_fpos = [*self._get_candidate_sites(structure)]
         for species in insert_species:
-            cand_sites, multiplicity, equiv_fpos = zip(*cand_sites_mul_and_equiv_fpos)
+            cand_sites, multiplicity, equiv_fpos = zip(
+                *cand_sites_mul_and_equiv_fpos, strict=False
+            )
 
             yield from super().generate(
                 structure,
@@ -490,7 +492,9 @@ class ChargeInterstitialGenerator(InterstitialGenerator):
             raise ValueError(msg)
         cand_sites_mul_and_equiv_fpos = [*self._get_candidate_sites(chgcar)]
         for species in insert_species:
-            cand_sites, multiplicity, equiv_fpos = zip(*cand_sites_mul_and_equiv_fpos)
+            cand_sites, multiplicity, equiv_fpos = zip(
+                *cand_sites_mul_and_equiv_fpos, strict=False
+            )
             if self.max_insertions is not None:
                 cand_sites = cand_sites[: self.max_insertions]
                 multiplicity = multiplicity[: self.max_insertions]

--- a/pymatgen/analysis/defects/plotting/thermo.py
+++ b/pymatgen/analysis/defects/plotting/thermo.py
@@ -59,7 +59,7 @@ def _plot_line(
     Returns:
         None, modifies the fig object in place.
     """
-    x_pos, y_pos = tuple(zip(*pts))
+    x_pos, y_pos = tuple(zip(*pts, strict=False))
     trace_ = go.Scatter(
         x=x_pos,
         y=y_pos,
@@ -108,13 +108,13 @@ def _label_slopes(fig: go.Figure) -> None:
         fig: A plotly figure object.
     """
     for data_ in filter(lambda x: x.meta.get("formation_energy_plot", False), fig.data):
-        transitions_arr_ = np.array(tuple(zip(data_.x, data_.y)))
+        transitions_arr_ = np.array(tuple(zip(data_.x, data_.y, strict=False)))
         diff_arr = transitions_arr_[1:] - transitions_arr_[:-1]
         slopes = tuple(
             int(slope) for slope in np.round(diff_arr[:, 1] / diff_arr[:, 0])
         )
         pos = (transitions_arr_[:-1] + transitions_arr_[1:]) / 2.0
-        x_pos, y_pos = tuple(zip(*pos))
+        x_pos, y_pos = tuple(zip(*pos, strict=False))
         fig.add_trace(
             go.Scatter(
                 x=x_pos,
@@ -203,6 +203,7 @@ def get_plot_data(
         grouped_feds,
         get_line_style_and_color_sequence(PLOTLY_COLORS, PLOTLY_STYLES),
         x_annos_,
+        strict=False,
     ):
         if chempot is None:
             cation_el_ = fed.chempot_diagram.elements[0]

--- a/pymatgen/analysis/defects/recombination.py
+++ b/pymatgen/analysis/defects/recombination.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 
 import itertools
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy.interpolate import PchipInterpolator
 
 from .constants import AMU2KG, ANGS2M, EV2J, HBAR_EV, HBAR_J, KB, LOOKUP_TABLE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _logger = logging.getLogger(__name__)
 

--- a/pymatgen/analysis/defects/supercells.py
+++ b/pymatgen/analysis/defects/supercells.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
-from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Lattice
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.util.coord_cython import pbc_shortest_vectors
 
 # from ase.build import find_optimal_cell_shape, get_deviation_from_optimal_cell_shape

--- a/pymatgen/analysis/defects/supercells.py
+++ b/pymatgen/analysis/defects/supercells.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from monty.dev import deprecated
-from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Lattice
 from pymatgen.util.coord_cython import pbc_shortest_vectors
 

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass, field
 from itertools import chain, groupby
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -20,10 +20,10 @@ from pymatgen.analysis.defects.finder import DefectSiteFinder
 from pymatgen.analysis.defects.supercells import get_closest_sc_mat
 from pymatgen.analysis.defects.utils import get_zfile, group_docs
 from pymatgen.analysis.phase_diagram import PhaseDiagram
-from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Composition, Element
-from pymatgen.electronic_structure.dos import FermiDos
 from pymatgen.core.entries import ComputedEntry
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
+from pymatgen.electronic_structure.dos import FermiDos
 from pymatgen.io.vasp import Locpot, Vasprun, VolumetricData
 from pyrho.charge_density import get_volumetric_like_sc
 from scipy.constants import value as _cd
@@ -31,7 +31,7 @@ from scipy.optimize import bisect
 from scipy.spatial import ConvexHull
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Callable, Generator, Sequence
 
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike, NDArray
@@ -523,7 +523,7 @@ class FormationEnergyDiagram(MSONable):
     def chempot_limits(self) -> list[dict[Element, float]]:
         """Return the chemical potential limits in dictionary format."""
         return [
-            dict(zip(self.chempot_diagram.elements, vertex))
+            dict(zip(self.chempot_diagram.elements, vertex, strict=False))
             for vertex in self._chempot_limits_arr
         ]
 
@@ -535,7 +535,9 @@ class FormationEnergyDiagram(MSONable):
         res = []
         for pt in self._chempot_limits_arr:
             competing_phases = {}
-            for hp_ent, hp in zip(cd._hyperplane_entries, cd._hyperplanes):
+            for hp_ent, hp in zip(
+                cd._hyperplane_entries, cd._hyperplanes, strict=False
+            ):
                 if hp_ent.composition.reduced_formula == bulk_formula:
                     continue
                 if _is_on_hyperplane(pt, hp):

--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -20,10 +20,10 @@ from pymatgen.analysis.defects.finder import DefectSiteFinder
 from pymatgen.analysis.defects.supercells import get_closest_sc_mat
 from pymatgen.analysis.defects.utils import get_zfile, group_docs
 from pymatgen.analysis.phase_diagram import PhaseDiagram
-from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core import Composition, Element
 from pymatgen.electronic_structure.dos import FermiDos
-from pymatgen.entries.computed_entries import ComputedEntry
+from pymatgen.core.entries import ComputedEntry
 from pymatgen.io.vasp import Locpot, Vasprun, VolumetricData
 from pyrho.charge_density import get_volumetric_like_sc
 from scipy.constants import value as _cd

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -18,8 +18,8 @@ import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
 from numpy.linalg import norm
-from pymatgen.analysis.local_env import CN_OPT_PARAMS
-from pymatgen.analysis.structure_matcher import StructureMatcher
+from pymatgen.core.local_env import CN_OPT_PARAMS
+from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
 from pymatgen.core.periodic_table import Element, get_el_sp
 from pymatgen.electronic_structure.core import Spin

--- a/pymatgen/analysis/defects/utils.py
+++ b/pymatgen/analysis/defects/utils.py
@@ -12,16 +12,16 @@ from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from monty.dev import deprecated
 from monty.json import MSONable
 from numpy.linalg import norm
-from pymatgen.core.local_env import CN_OPT_PARAMS
-from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
+from pymatgen.core.local_env import CN_OPT_PARAMS
 from pymatgen.core.periodic_table import Element, get_el_sp
+from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.electronic_structure.core import Spin
 from pymatgen.io.vasp.sets import get_valid_magmom_struct
 from pymatgen.util.coord import pbc_diff
@@ -30,7 +30,7 @@ from scipy.spatial import ConvexHull, Voronoi
 from scipy.spatial.distance import squareform
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Callable, Generator, Sequence
     from pathlib import Path
 
     from numpy import typing as npt
@@ -178,7 +178,7 @@ def genrecip(
     radii = np.sqrt(np.einsum("ij,ij->i", vecs, vecs))
 
     # Yield based on radii
-    for vec, r in zip(vecs, radii):
+    for vec, r in zip(vecs, radii, strict=False):
         if r < G_cut and r != 0:
             yield vec
 
@@ -963,13 +963,13 @@ def sort_positive_definite(
     D0 = dist(ref1, ref2)
 
     d_vs_s = []
-    for q1, q2, el in zip(d1, d2, list_in):
+    for q1, q2, el in zip(d1, d2, list_in, strict=False):
         sign = +1
         if q1 < q2 and q2 > D0:
             sign = -1
         d_vs_s.append((sign * q1, el))
     d_vs_s.sort()
-    distances, sorted_list = list(zip(*d_vs_s))
+    distances, sorted_list = list(zip(*d_vs_s, strict=False))
     return sorted_list, distances
 
 
@@ -1035,7 +1035,7 @@ def get_labeled_inserted_structure(
 
     # Label the groups by structure matching
     site_labels = generic_group_labels(inserted_structs, comp=sm.fit)
-    return [*zip(sites.tolist(), site_labels)]
+    return [*zip(sites.tolist(), site_labels, strict=False)]
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = '>=3.11'
 finder = ["dscribe>=2.0.0"]
 dev = ["pre-commit>=2.12.1"]
 docs = [
-  "jupyter-book>=0.13.1",
+  "jupyter-book>=0.13.1,<2",
 ]
 optional = ["pydefect", "dscribe>=2.0.0", "numba"]
 tests = ["pytest>=8.2.1", "pytest-cov>=5.0.0", "nbmake>=1.5.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,6 @@ requires = ["setuptools >= 42", "versioningit >= 1,< 4", "wheel"]
 authors = [{ name = "Jimmy-Xuan Shen", email = "jmmshn@gmail.com" }]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
@@ -16,7 +14,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "pymatgen>=2024.10.22",
+  "pymatgen-core>=2026.4.7",
   "scikit-image>=0.19.3",
   "numpy>=2.0.0,<3.0.0",
   "mp-pyrho>=0.4.4",
@@ -27,7 +25,7 @@ keywords = ["high-throughput", "automated", "dft", "defects"]
 license = "BSD-3-Clause-LBNL"
 name = "pymatgen-analysis-defects"
 readme = "README.md"
-requires-python = '>=3.9'
+requires-python = '>=3.11'
 
 [project.optional-dependencies]
 finder = ["dscribe>=2.0.0"]

--- a/tests/test_files/stable_entries_Mg_Ga_N.json
+++ b/tests/test_files/stable_entries_Mg_Ga_N.json
@@ -1,6 +1,6 @@
 [
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -38.42229507,
         "composition": {
@@ -35,7 +35,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -29.86997198,
         "composition": {
@@ -70,7 +70,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -201.83378403,
         "composition": {
@@ -81,18 +81,13 @@
         "correction": -5.776,
         "energy_adjustments": [
             {
-                "@module": "pymatgen.entries.computed_entries",
+                "@module": "pymatgen.core.entries",
                 "@class": "CompositionEnergyAdjustment",
                 "@version": null,
                 "adj_per_atom": -0.361,
                 "n_atoms": 16.0,
                 "uncertainty_per_atom": 0.0093,
                 "name": "MP2020 anion correction (N)",
-                "cls": {
-                    "@module": "pymatgen.entries.compatibility",
-                    "@class": "MaterialsProject2020Compatibility",
-                    "@version": null
-                },
                 "description": "Composition-based energy adjustment"
             }
         ],
@@ -124,7 +119,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -39.4000992,
         "composition": {
@@ -159,7 +154,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -39.83410568,
         "composition": {
@@ -194,7 +189,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -12.11235968,
         "composition": {
@@ -225,7 +220,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -4.79068775,
         "composition": {
@@ -256,7 +251,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -245.82917071,
         "composition": {
@@ -291,7 +286,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -24.63444937,
         "composition": {
@@ -302,18 +297,13 @@
         "correction": -0.722,
         "energy_adjustments": [
             {
-                "@module": "pymatgen.entries.computed_entries",
+                "@module": "pymatgen.core.entries",
                 "@class": "CompositionEnergyAdjustment",
                 "@version": null,
                 "adj_per_atom": -0.361,
                 "n_atoms": 2.0,
                 "uncertainty_per_atom": 0.0093,
                 "name": "MP2020 anion correction (N)",
-                "cls": {
-                    "@module": "pymatgen.entries.compatibility",
-                    "@class": "MaterialsProject2020Compatibility",
-                    "@version": null
-                },
                 "description": "Composition-based energy adjustment"
             }
         ],
@@ -345,7 +335,7 @@
         "@version": null
     },
     {
-        "@module": "pymatgen.entries.computed_entries",
+        "@module": "pymatgen.core.entries",
         "@class": "ComputedEntry",
         "energy": -66.69195172,
         "composition": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from pymatgen.analysis.defects.utils import (
     get_plane_spacing,
     group_docs,
 )
-from pymatgen.analysis.structure_matcher import StructureMatcher
+from pymatgen.core.structure_matcher import StructureMatcher
 from pymatgen.core.periodic_table import Specie
 from pymatgen.io.vasp.outputs import Chgcar
 


### PR DESCRIPTION
This refactors the imports and dependencies of `pymatgen-analysis-defects` so that it only requires `pymatgen-core`, and not the full extended `pymatgen` suite. All tests pass locally.

I also noticed that the pmg analysis defects docs: https://materialsproject.github.io/pymatgen-analysis-defects/ is not rendering. This PR includes a fix which may resolve that (though I'm not sure if it will fully resolve that issue).