### PR TITLE
ci(dependabot): raise open-PR limit; watch github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,15 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 2
+  open-pull-requests-limit: 5
   allow:
   - dependency-type: direct
   - dependency-type: indirect
   ignore:
     - dependency-name: mistune
     - dependency-name: numpy
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5


### PR DESCRIPTION
Two small improvements to `.github/dependabot.yml`.

## Changes

1. `pip` ecosystem: raise `open-pull-requests-limit` from 2 → 5. With limit=2, newer autoupdate PRs never open while older bumps sit for months (PR #223 waited ~4 months as a side effect).
2. Add a `github-actions` `updates:` entry so Action pins get security bumps too.

Left alone in this PR (call out for follow-up):

- The `ignore: numpy` rule may be over-broad now that numpy 2.x is the pinned floor. Worth revisiting separately.

Bead: pmg-defects-epic.12