### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     env:
       PMG_MAPI_KEY: ${{ secrets.PMG_MAPI_KEY }}


### PR DESCRIPTION
Adds Python 3.14 to the CI test matrix (currently 3.11 / 3.12 / 3.13).

## Dependency wheel check

All required deps have Python 3.14 support on PyPI:

- pymatgen-core 2026.7.16 — has cp314 wheels
- numpy 2.5.1 — has cp314 wheels
- scikit-image 0.26.0 — has cp314 wheels
- matplotlib 3.11.1 — has cp314 wheels
- contourpy 1.3.3 — has cp314 wheels
- mp-pyrho 0.5.1 — pure-Python (py3 wheel)
- pytest 9.1.1 — pure-Python (py3 wheel)
- pytest-cov 7.1.0 — pure-Python (py3 wheel)
- nbmake 1.5.5 — pure-Python (py3 wheel)

## Notes

No `continue-on-error` workaround needed — all C-extension deps ship cp314 wheels.

Bead: pmg-defects-epic.13