### PR TITLE
fix(thermo): guard empty legend under matplotlib 3.11+

### DIFF
--- a/pymatgen/analysis/defects/thermo.py
+++ b/pymatgen/analysis/defects/thermo.py
@@ -1357,13 +1357,16 @@ def plot_formation_energy_diagrams(
         else:
             handle, leg = [], []
 
-        axis.legend(
-            handles=artists + handle,
-            labels=legends_txt + leg,
-            fontsize=lg_fontsize * ax_fontsize,
-            ncol=3,
-            loc=legend_loc,
-        )
+        combined_handles = artists + handle
+        combined_labels = legends_txt + leg
+        if combined_handles and combined_labels:
+            axis.legend(
+                handles=combined_handles,
+                labels=combined_labels,
+                fontsize=lg_fontsize * ax_fontsize,
+                ncol=3,
+                loc=legend_loc,
+            )
 
     if save:
         save = save if isinstance(save, str) else "formation_energy_diagram.png"


### PR DESCRIPTION
Fixes the `tests/test_thermo.py::test_plotter` failure that has been red on `main` since 2026-06-12.

## Root cause

matplotlib 3.11.x tightened `_parse_legend_args`. On the failing branch of `test_plotter`, both `artists + handle` and `legends_txt + leg` are empty; the prior `axis.legend(handles=[], labels=[], ...)` call previously warned but is now a `ValueError`.

## Fix

Skip `axis.legend(...)` entirely when the combined handles/labels are empty. No behavior change for callers that actually pass artists — the old empty-legend was already a no-op modulo the warning.

## Verification

```
pytest tests/test_thermo.py::test_plotter -x  # was ValueError, now passes
pytest tests/test_thermo.py -x                # full file green
```

Reproduced pre-fix locally on matplotlib==3.11.1.

Bead: pmg-defects-epic.7